### PR TITLE
Allow passing component configuration options in environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,16 @@ workflow by running during a component's `didRender` phase in non-production
 environments. This gives you instant feedback on if your component's are
 accessible in any given state.
 
-## Future Plans
-
-Now that your components and acceptance tests can self-audit, the next step
-going forward is to give helpful and meaningful feedback to developers. This
-means easily highlighting areas with violations and giving suggestions on how to
-fix and improve them. Additionally, work will be done to tackle Ember-specific
-accessibility issues, such as identifying actions on inaccessible elements.
-
-## Usage In Testing
-
-Usage inside tests right now is super simple, just install the addon via:
+## Installation
 
 ```bash
 ember install ember-a11y-testing
 ```
 
-That's it! It will automatically begin running during _acceptance_ tests. It
+## Usage
+
+### Testing Usage
+By default, Ember A11y Testing will automatically begin running during _acceptance_ tests. It
 also injects the `axe` object globally during development so you can run tests
 while developing your application as well.
 
@@ -40,7 +33,7 @@ to occupy the entire screen. This is to simulate the actual application
 environment, as browsers adjust styles at small sizes for accessibility reasons.
 It will reset itself at the conclusion of testing though.
 
-### Disable/Enable Tests
+#### Disabling/Enabling Axe During Tests
 
 By default, the axe-core tests only run during acceptance tests. In order to
 enable them for other tests, simply run the following at the beginning of your
@@ -56,7 +49,7 @@ On the flip side, if you want to turn tests off, simply use:
 axe.ember.turnAxeOff();
 ```
 
-### Options
+#### Setting Axe Test Options
 
 You can pass specific options to be used during `a11yCheck` by setting them on a
 global `testOptions` property:
@@ -74,13 +67,14 @@ You can see the available options in the [axe-core repo](https://github.com/dequ
 
 _Note:_ the options will stay set, until set to something different.
 
-## Usage In Development
+
+### Development Usage
 
 Usage in development is restricted to applications using Ember 1.13 and up as it
 relies on the `didRender` hook of a component's life-cycle (a feature only
 available in versions of Ember with the Glimmer rendering engine).
 
-That said, setup for development is as simple as it is for testing, simply
+That said, setup for development is as simple as it is for testing: simply
 install the addon.
 
 By default, Ember A11y Testing will audit a component for accessibility each
@@ -88,14 +82,14 @@ time it is rendered. This ensures that the component is still accessible even
 after state changes, and since the checks are scoped to a component's element,
 it means that any state change propagated downwards is also caught.
 
-### Component Hooks
+#### Component Hooks
 
 Since development is not a uniform experience, Ember A11y Testing provides
 several hooks to help stay out of the way.
 
 _Note:_ these are all `undefined` by default.
 
-#### Defining a custom callback
+##### Defining a custom callback
 
 If you feel the logging of violations is poor or you just want to see the entire
 results of a component's audit, you can define a custom callback. The callback
@@ -108,7 +102,7 @@ axeCallback(results) {
 }
 ```
 
-#### Setting options for the audit
+##### Setting options for the audit
 
 As with testing, if you need to set custom auditing options for a component, you
 can do so easily. Simply set a value for the `axeOptions` property value:
@@ -117,7 +111,7 @@ can do so easily. Simply set a value for the `axeOptions` property value:
 axeOptions: { /* a11yCheck options */ }
 ```
 
-#### Turning the audit off
+##### Turning the audit off
 
 Lastly, if you really find the audits to be cramping development, you can turn
 them off via a simple boolean switch:
@@ -125,3 +119,24 @@ them off via a simple boolean switch:
 ```javascript
 turnAuditOff: true
 ```
+
+#### Environment Options
+Each of the fine-grained component hooks above can instead be defined for ALL components inside of your application's `config/environment.js` file. Simply supply them in a `componentOptions` hash on the `ember-a11y-testing` property of `ENV`.
+
+```javascript
+ENV['ember-a11y-testing'] = {
+    componentOptions: {
+      turnAuditOff: true
+      ...
+    }
+  }
+};
+```
+
+## Future Plans
+
+Now that your components and acceptance tests can self-audit, the next step
+going forward is to give helpful and meaningful feedback to developers. This
+means easily highlighting areas with violations and giving suggestions on how to
+fix and improve them. Additionally, work will be done to tackle Ember-specific
+accessibility issues, such as identifying actions on inaccessible elements.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ _Note:_ the options will stay set, until set to something different.
 
 ### Development Usage
 
-Usage in development is restricted to applications using Ember 1.13 and up as it
+Usage in development is restricted to applications using Ember 1.13, and up as it
 relies on the `didRender` hook of a component's life-cycle (a feature only
 available in versions of Ember with the Glimmer rendering engine).
 
@@ -121,13 +121,13 @@ turnAuditOff: true
 ```
 
 #### Environment Options
-Each of the fine-grained component hooks above can instead be defined for ALL components inside of your application's `config/environment.js` file. Simply supply them in a `componentOptions` hash on the `ember-a11y-testing` property of `ENV`.
+With the exception of `turnAuditOff`, each of the fine-grained component hooks above can instead be defined for ALL components inside of your application's `config/environment.js` file. Simply supply them in a `componentOptions` hash on the `ember-a11y-testing` property of `ENV`.
 
 ```javascript
 ENV['ember-a11y-testing'] = {
     componentOptions: {
-      turnAuditOff: true
-      ...
+      axeCallback: defaultAxeCallback,
+      axeOptions: defaultAxeOptions
     }
   }
 };

--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -1,3 +1,5 @@
+import ENV from '../config/environment';
+
 /**
  * Variable to ensure that the initializer is only ran once. Though in this
  * particular case, running more than once shouldn't cause side-effects.
@@ -8,27 +10,32 @@ let hasRan = false;
 export function initialize(application) {
   if (hasRan) { return; }
 
+  const appConfig = ENV['ember-a11y-testing'] || {};
+  const { componentOptions: { axeOptions, turnAuditOff, axeCallback } = {} } = appConfig;
+
   Ember.Component.reopen({
     /**
      * An optional callback to process the results from the a11yCheck.
      * @public
      * @type {Function}
      */
-    axeCallback: undefined,
+    axeCallback,
 
     /**
      * An optional options object to be used in a11yCheck.
      * @public
      * @type {Object}
      */
-    axeOptions: undefined,
+    axeOptions,
 
     /**
      * Turns off the accessibility audit during rendering.
+     * Defaults to false if not set in the application's configuration.
+     *
      * @public
      * @type {Boolean}
      */
-    turnAuditOff: false,
+    turnAuditOff: typeof turnAuditOff === 'boolean' ? turnAuditOff : false,
 
     /**
      * Runs an accessibility audit on any render of the component.

--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -10,12 +10,14 @@ let hasRan = false;
 export function initialize(application) {
   if (hasRan) { return; }
 
-  const appConfig = ENV['ember-a11y-testing'] || {};
-  const { componentOptions: { axeOptions, turnAuditOff, axeCallback } = {} } = appConfig;
+  const addonConfig = ENV['ember-a11y-testing'] || {};
+  const { componentOptions: { axeOptions, axeCallback } = {} } = addonConfig;
 
   Ember.Component.reopen({
     /**
      * An optional callback to process the results from the a11yCheck.
+     * Defaults to `undefined` if not set in the application's configuration.
+     *
      * @public
      * @type {Function}
      */
@@ -23,6 +25,7 @@ export function initialize(application) {
 
     /**
      * An optional options object to be used in a11yCheck.
+     * Defaults to `undefined` if not set in the application's configuration.
      * @public
      * @type {Object}
      */
@@ -30,12 +33,11 @@ export function initialize(application) {
 
     /**
      * Turns off the accessibility audit during rendering.
-     * Defaults to false if not set in the application's configuration.
      *
      * @public
      * @type {Boolean}
      */
-    turnAuditOff: typeof turnAuditOff === 'boolean' ? turnAuditOff : false,
+    turnAuditOff: false,
 
     /**
      * Runs an accessibility audit on any render of the component.


### PR DESCRIPTION
I like the additional options being enabled for components, but I've found that sometimes it can be useful to A) set app-wide component defaults, and/or B) easily control these app-wide settings on the fly during development.

This led me to making  `ember-a11y-testing` configurable through the app’s ENV hash:

```javascript
ENV['ember-a11y-testing'] = {
    componentOptions: {
      turnAuditOff: true
      ...
    }
  }
};
```

All we’d have to do is have our instance initializer read in the hash from `../config/environment`, and the component properties for `axeOptions`, `axeCallback`, `turnAuditOff` have the opportunity to be set to what’s defined on `ENV['ember-a11y-testing'].componentOptions.` (Side note: I layered in the `componentOptions` property so that -- if we're okay with this approach -- we could flexibly add similarly separated hashes for whatever `xOptions` might be desirable in the future.)

Additionally, trying to update `README.md` for this lead me to finding a number of ways that it could be structured more cleanly — and I ended up moving a few pieces around in ways that I think help the overall readability (regardless of the other changes introduced by the PR).