### PR TITLE
Add more descriptive violation logging

### DIFF
--- a/content-for/test-body-footer.html
+++ b/content-for/test-body-footer.html
@@ -14,12 +14,33 @@
     a11yCheckCallback: function(results) {
       var violations = results.violations;
 
-      for (var i = 0, l = violations.length; i < l; i++) {
-        Ember.Logger.error('Violation #' + (i + 1), violations[i]);
-      }
+      if (violations.length) {
+        Ember.Logger.error('ACCESSIBILITY VIOLATIONS: ' + violations.length);
 
-      Ember.assert('The page should have no accessibility violations.', !violations.length);
+        for (var i = 0, l = violations.length; i < l; i++) {
+          var violation = violations[i];
+          var violationNodeString = axe.ember.nodesToString(violation.nodes);
+
+          Ember.Logger.warn(violation.impact.toUpperCase() + ': ' + violation.help);
+          Ember.Logger.info('Offending markup (' + violation.nodes.length + '): ' + violationNodeString);
+          Ember.Logger.info('Additional info: ' + violation.helpUrl);
+          Ember.Logger.info('-------------------------------------');
+        }
+      }
+      Ember.assert('The page should have no accessibility violations. Please check the developer console for more details.', !violations.length);
     },
+
+    /**
+     * Takes the violations' nodes param and converts it to
+     * a string that can be displayed with the console error.
+     * @param {Array} nodes
+     * @return {String}
+     */
+     nodesToString: function(nodes) {
+       return nodes.map(function(node) {
+         return node.html;
+       }).join(', ');
+     },
 
     /**
      * Used as a callback for afterRender. Simply runs axe.a11yCheck and passes

--- a/content-for/test-body-footer.html
+++ b/content-for/test-body-footer.html
@@ -19,10 +19,11 @@
 
         for (var i = 0, l = violations.length; i < l; i++) {
           var violation = violations[i];
-          var violationNodeString = axe.ember.nodesToString(violation.nodes);
+          var violationNodes = axe.ember.generateNodesArray(violation.nodes);
 
           Ember.Logger.warn(violation.impact.toUpperCase() + ': ' + violation.help);
-          Ember.Logger.info('Offending markup (' + violation.nodes.length + '): ' + violationNodeString);
+          Ember.Logger.info('Offending markup (' + violation.nodes.length + ')');
+          Ember.Logger.debug(violationNodes);
           Ember.Logger.info('Additional info: ' + violation.helpUrl);
           Ember.Logger.info('-------------------------------------');
         }
@@ -32,14 +33,14 @@
 
     /**
      * Takes the violations' nodes param and converts it to
-     * a string that can be displayed with the console error.
+     * an array that constains only offending markup HTML.
      * @param {Array} nodes
-     * @return {String}
+     * @return {Array}
      */
-     nodesToString: function(nodes) {
+     generateNodesArray: function(nodes) {
        return nodes.map(function(node) {
          return node.html;
-       }).join(', ');
+       });
      },
 
     /**

--- a/tests/unit/test-body-footer-test.js
+++ b/tests/unit/test-body-footer-test.js
@@ -37,9 +37,9 @@ test('a11yCheckCallback should log any violations and throw an error', function(
 
   assert.throws(() => {
     axe.ember.a11yCheckCallback({ violations: [ {}, {} ] });
-  }, 'The page should have no accessibility violations.');
+  }, 'The page should have no accessibility violations. Please check the developer console for more details.');
 
-  assert.ok(loggerStub.calledTwice);
+  assert.equal(loggerStub.callCount, 1, 'An error is thrown when there are violations');
 });
 
 /* axe.ember.afterRender */


### PR DESCRIPTION
Original PR from ember-axe: https://github.com/trentmwillis/ember-axe/pull/7

As we are about to use this add-on in a new application, the other developer and I thought it would be nice to have more descriptive logging in the console rather than sifting through the `violations` object output.

This both updates the default messages that is displayed inside the browser test runner, along with more precise console logging, rather than dumping the entire `violations` object flat out.

#### New test runner messaging
<img width="1438" alt="screen shot 2016-05-12 at 8 34 10 pm" src="https://cloud.githubusercontent.com/assets/579649/15234958/4b00906c-1885-11e6-8300-8a6efcb2b2bb.png">

#### New console level information
<img width="897" alt="screen shot 2016-06-09 at 11 08 32 am" src="https://cloud.githubusercontent.com/assets/579649/15934748/a5ef545a-2e32-11e6-8df6-ef4ac1cdb441.png">
