### PR TITLE
Update dependencies and project structure for Ember-CLI 2.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,15 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - npm config set spin false
+  - npm install -g bower
+  - npm install phantomjs-prebuilt
 
 install:
-  - npm install -g bower
   - npm install
   - bower install
 
 script:
-  - ember try $EMBER_TRY_SCENARIO test
+  # Usually, it's ok to finish the test scenario without reverting
+  #  to the addon's original dependency state, skipping "cleanup".
+  - ember try $EMBER_TRY_SCENARIO test --skip-cleanup

--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "ember-a11y-testing",
   "dependencies": {
-    "ember": "~2.5.0",
+    "axe-core": "~1.1.1",
+    "ember": "~2.6.0",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "axe-core": "~1.1.1",
     "sinonjs": "~1.14.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall"
+    "test": "ember try:each"
   },
   "repository": {
     "type": "git",
@@ -22,8 +22,8 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "ember-ajax": "0.7.1",
-    "ember-cli": "2.5.1",
+    "ember-ajax": "^2.0.1",
+    "ember-cli": "2.6.2",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.3",
@@ -31,16 +31,14 @@
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^1.4.0",
-    "ember-cli-release": "0.2.8",
+    "ember-cli-release": "0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.5.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.5.1",
-    "ember-try": "0.2.2",
     "loader.js": "^4.0.1"
   },
   "keywords": [

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -26,7 +26,7 @@
   "node": false,
   "browser": false,
   "boss": true,
-  "curly": false,
+  "curly": true,
   "debug": false,
   "devel": false,
   "eqeqeq": true,
@@ -47,5 +47,6 @@
   "strict": false,
   "white": false,
   "eqnull": true,
-  "esnext": true
+  "esnext": true,
+  "unused": true
 }

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,6 +1,9 @@
 import { module } from 'qunit';
+import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
+
+const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {
@@ -8,16 +11,13 @@ export default function(name, options = {}) {
       this.application = startApp();
 
       if (options.beforeEach) {
-        options.beforeEach.apply(this, arguments);
+        return options.beforeEach.apply(this, arguments);
       }
     },
 
     afterEach() {
-      if (options.afterEach) {
-        options.afterEach.apply(this, arguments);
-      }
-
-      destroyApp(this.application);
+      let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
+      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
     }
   });
 }

--- a/tests/unit/instance-initializers/axe-component-test.js
+++ b/tests/unit/instance-initializers/axe-component-test.js
@@ -93,7 +93,7 @@ test('turnAuditOff prevents audit from running on didRender', function(assert) {
 /* Ember.Component.audit */
 
 test('audit should log any violations found', function(assert) {
-  let a11yCheckStub = sandbox.stub(axe, 'a11yCheck', function(el, options, callback) {
+  sandbox.stub(axe, 'a11yCheck', function(el, options, callback) {
     callback({
       violations: [{
         name: 'test',
@@ -110,12 +110,12 @@ test('audit should log any violations found', function(assert) {
   assert.ok(logSpy.calledOnce);
 });
 
-skip('audit should mark the DOM nodes of any violations', function(assert) {
+skip('audit should mark the DOM nodes of any violations', function(/* assert */) {
 
 });
 
 test('audit should do nothing if no violations found', function(assert) {
-  let a11yCheckStub = sandbox.stub(axe, 'a11yCheck', function(el, options, callback) {
+  sandbox.stub(axe, 'a11yCheck', function(el, options, callback) {
     callback({
       violations: []
     });
@@ -133,7 +133,8 @@ test('audit should do nothing if no violations found', function(assert) {
 
 test('axeCallback receives the results of the audit', function(assert) {
   let results = { violations: [] };
-  let a11yCheckStub = sandbox.stub(axe, 'a11yCheck', (el, opts, callback) => {
+
+  sandbox.stub(axe, 'a11yCheck', (el, opts, callback) => {
     callback(results);
   });
 
@@ -150,7 +151,8 @@ test('axeCallback receives the results of the audit', function(assert) {
 
 test('axeCallback throws an error if it is not a function', function(assert) {
   let results = { violations: [] };
-  let a11yCheckStub = sandbox.stub(axe, 'a11yCheck', (el, opts, callback) => {
+
+  sandbox.stub(axe, 'a11yCheck', (el, opts, callback) => {
     callback(results);
   });
 


### PR DESCRIPTION
This PR updates the project to `ember-cli` @ 2.6.2 and makes a few relevant [changes for the new version](https://github.com/ember-cli/ember-cli/releases). 

Mainly...
* Update tests to pass `jshint` after it started finding unused variables.
* Update minor & patch versions of various dependencies in `package.json`
* Update `npm test` command to run `ember try:each`
* Update `.travis.yml` to use the latest `before_install` and `script` settings.
* Remove `ember-try` as a `devDependency` -- it's now included with Ember CLI.