### PR TITLE
Update axe-core Dependency and explicitly match it in the afterInstall hook

### DIFF
--- a/blueprints/ember-a11y-testing/index.js
+++ b/blueprints/ember-a11y-testing/index.js
@@ -4,6 +4,6 @@ module.exports = {
   normalizeEntityName: function() { },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('axe-core');
+    return this.addBowerPackageToProject('axe-core', '1.1.1');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
-    "axe-core": "~1.0.1",
+    "axe-core": "~1.1.1",
     "sinonjs": "~1.14.1"
   }
 }


### PR DESCRIPTION
This PR addresses an inconsistency that I found between the version of `axe-core` that we're using internally in the project, and the one that we're adding to consuming project via the blueprint's `afterInstall` hook. 

Basically, [not specifying a version here](https://github.com/ember-a11y/ember-a11y-testing/compare/master...BrianSipple:update-to-axe-core-1.1.1-and-fix-adding-to-project?expand=1#diff-26407cd03de86c22a240984245d3ab49L7) has the same effect as just running `bower install axe-core`: The latest version is what gets used. 

For consuming apps, there's a bit of serendipity here, because 1.1.1 appears to have improved catching violations in a few ways and using it lead to me noticing the inconsistency in the first place. But in short, 
the current state can be tested by installing `ember-a11y-testing` in an application and creating a component that consists of an empty button (no inner content like a title). You get a violation. And, if you debug the `audit` function and log out `axe`, the version reads as `1.1.1`. Now create that same button component in the dummy app and use it in `application.hbs`. The axe version is `1.0.1` and no violation is caught.