### PR TITLE
Set turnAuditOff in init and clean up Ember.testing toggling in tests

### DIFF
--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -7,11 +7,12 @@ import ENV from '../config/environment';
  */
 let hasRan = false;
 
-export function initialize(application) {
-  if (hasRan) { return; }
+export function initialize(application, opts = { forceRun: false }) {
+  if (hasRan && !opts.forceRun) { return; }
 
   const addonConfig = ENV['ember-a11y-testing'] || {};
   const { componentOptions: { axeOptions, axeCallback } = {} } = addonConfig;
+
 
   Ember.Component.reopen({
     /**
@@ -34,10 +35,11 @@ export function initialize(application) {
     /**
      * Turns off the accessibility audit during rendering.
      *
+     * defaults to true in testing, false otherwise
      * @public
      * @type {Boolean}
      */
-    turnAuditOff: false,
+    turnAuditOff: !!Ember.testing,
 
     /**
      * An array of classNames to add to the component when a violation occurs.
@@ -49,17 +51,15 @@ export function initialize(application) {
      */
     axeViolationClassNames: ['axe-violation'],
 
+    didRender() {
+      this._super(...arguments);
+      console.log(`didRender(): Checking Ember.testing: ${Ember.testing}`);
 
-    /**
-     * Runs an accessibility audit on any render of the component.
-     * @private
-     * @return {Void}
-     */
-    _runAudit: Ember.on('didRender', function() {
-      if (this.turnAuditOff || Ember.testing) { return; }
-
-      this.audit();
-    }),
+      // Run an accessibility audit on any render of the component.
+      if (!this.turnAuditOff) {
+        this.audit();
+      }
+    },
 
     /**
      * Runs the axe a11yCheck audit and logs any violations to the console. It

--- a/tests/unit/instance-initializers/axe-component-test.js
+++ b/tests/unit/instance-initializers/axe-component-test.js
@@ -39,29 +39,37 @@ test('initializer should not re-open Component more than once', function(assert)
   assert.ok(reopenSpy[assertMethod]);
 });
 
-test('audit is run on didRender when not in testing mode', function(assert) {
-  initialize(application);
 
-  let component = Component.create({});
+test('audit is run on didRender when not in testing mode', function(assert) {
+  // In order for the audit to run, Ember.testing has to be false
+  // when the component is initialized
+  Ember.testing = false;
+  console.log('Test for running audit: Calling initialize after setting Ember.testing to false');
+  initialize(application, { forceRun: true });
+  Ember.testing = true;
+
+  console.log('Test for running audit: Creating component');
+  let component = Ember.Component.create({});
+
+  console.log('Test for running audit: Creating spy');
   let auditSpy = sandbox.spy(component, 'audit');
 
-  // In order for the audit to run, we have to act like we're not in testing
-  Ember.testing = false;
+  console.log('Test for running audit: appending component');
+  Ember.run(() => component.appendTo('#ember-testing'));
 
-  run(() => component.appendTo('#ember-testing'));
+  console.log('Test for running audit: Testing spy after appending component');
   assert.ok(auditSpy.calledOnce);
 
   run(() => component.trigger('didRender'));
+
+  console.log('Test for running audit: Testing spy after manually triggering `didRender`');
   assert.ok(auditSpy.calledTwice);
 
   run(() => component.destroy());
-
-  // Turn testing mode back on to ensure validity of other tests
-  Ember.testing = true;
 });
 
 test('audit is not run on didRender when in testing mode', function(assert) {
-  initialize(application);
+  initialize(application, { forceRun: true });
 
   let component = Component.create({});
   let auditSpy = sandbox.spy(component, 'audit');
@@ -75,21 +83,15 @@ test('audit is not run on didRender when in testing mode', function(assert) {
 /* Component.turnAuditOff */
 
 test('turnAuditOff prevents audit from running on didRender', function(assert) {
-  initialize(application);
+  initialize(application, { forceRun: true });
 
   let component = Component.create({ turnAuditOff: true });
   let auditSpy = sandbox.spy(component, 'audit');
 
-  // In order for the audit to run, we have to act like we're not in testing
-  Ember.testing = false;
-
   run(() => component.appendTo('#ember-testing'));
   assert.ok(auditSpy.notCalled);
 
-  run(() => component.destroy());
-
-  // Turn testing mode back on to ensure validity of other tests
-  Ember.testing = true;
+  Ember.run(() => component.destroy());
 });
 
 /* Component.audit */


### PR DESCRIPTION
After playing around in the current test suite a bit, it seems like we could stand to clean up both the way we set `turnAuditOff`, and the way we then test for it.

1) Rather than inspecting `Ember.testing` every time the `didRender` hook is called, we could just check it once inside of `init`. This way, the logic inside of `didRender` doesn't have to worry about `Ember.testing` and can use  `turnAuditOff` off as the "sole source of truth”.

2) It also seems like we only need to test for this behavior once -- and so I remove the `Ember.testing` toggling within the `audit is not run on didRender when in testing mode` test

**[NOTE]** The current CI failures here are resolved in https://github.com/ember-a11y/ember-a11y-testing/pull/36
