### PR TITLE
Use Chrome for CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,15 @@ node_js:
   - "5"
   - "6"
 
-sudo: false
+sudo: required
+dist: trusty
+
+addons:
+  apt:
+    sources:
+    - google-chrome
+    packages:
+    - google-chrome-stable
 
 cache:
   directories:
@@ -26,7 +34,8 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
   - "npm config set spin false"
   - "npm install -g npm@^2"
 

--- a/testem.js
+++ b/testem.js
@@ -4,10 +4,9 @@ module.exports = {
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [
-    "PhantomJS"
+    "Chrome"
   ],
   "launch_in_dev": [
-    "PhantomJS",
     "Chrome"
   ]
 };


### PR DESCRIPTION
From what I've been able to gather, the test failures in https://github.com/ember-a11y/ember-a11y-testing/pull/28 all seem to be due to PhantomJS not supporting either Array.find or HTMLElement.remove(). 

All tests pass in Chrome.

With that in mind, now might be a great opportunity to set up Chrome for CI tests -- especially given how much we're doing with the DOM. All we need is a few `travis.yml` and `testem` tweaks, and we'd be all set. 