### PR TITLE
Expose violationsHelper to global scope.

### DIFF
--- a/addon/utils/violations-helper.js
+++ b/addon/utils/violations-helper.js
@@ -1,0 +1,103 @@
+import Ember from 'ember';
+/**
+ * @module ember-a11y-testing
+ *
+ *
+ * Use the violations helper to inspect the collection of violations.
+ * This provides a set of handy helper methods so you can quickly query
+ * and filter the violations from the console.
+ *
+ *
+ * Helper methods include:
+ * - count
+ * - first
+ * - last
+ * - push
+ * - filterBy
+ *
+ * @public
+ * @class ViolationsHelper
+ */
+export default class ViolationsHelper {
+  /**
+   * Instantiate by calling either:
+   *
+   * new ViolationsHelper() or
+   * new ViolationsHelper(violation1, violation2, ...)
+   *
+   */
+  constructor() {
+    this.violations = Array.prototype.slice.call(arguments);
+    this.hasLoggedTip = false;
+  }
+
+  /**
+   * Alias method to return the current number of violations
+   *
+   * @public
+   * @type {Number}
+   */
+  get count() { return this.violations.length; }
+
+  /**
+   * Alias method to return the first violation
+   *
+   * @public
+   * @type {Object}
+   */
+  get first() { return this.violations[0]; }
+
+  /**
+   * Alias method to return the last violation
+   *
+   * @public
+   * @type {Object}
+   */
+  get last() { return this.violations[this.count - 1]; }
+
+  /**
+   * Alias method to push a violation into the collection
+   *
+   * @public
+   * @return {Void}
+   */
+  push(violation) {
+    this.violations.push(violation);
+  }
+
+  /**
+   * Filters violations by a key value pair such as:
+   * key = "impact", value = "critical"
+   *
+   * Special cases:
+   * The "rule" key is an alias for the "id" key.
+   * The "node" key filters violations by nodes with the selector of value.
+   *
+   * @public
+   * @return {Array}
+   */
+  filterBy(key, value) {
+    if (key === "rule") { key = "id"; }
+
+    return this.violations.filter((violation) => {
+      if (key === "node") {
+        return violation.nodes[0].target[0] === value;
+      }
+      return violation[key] === value;
+    });
+  }
+
+  /**
+   * Logs the tips for using violatonHelper in the console.
+   * Only logs if there are existing violations and the tip has not been logged before.
+   *
+   * @type {Function}
+   */
+  logTip() {
+    if (this.count && !this.hasLoggedTip) {
+      Ember.Logger.info("You can inspect or filter your violations from the console with: window.violationsHelper");
+      Ember.Logger.info("For a description of violationsHelper's API, see: https://github.com/ember-a11y/ember-a11y-testing/blob/master/addon/utils/violations-helper.js");
+      this.hasLoggedTip = true;
+    }
+  }
+}

--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -64,7 +64,8 @@ export function initialize(application) {
 
     /**
      * Runs the axe a11yCheck audit and logs any violations to the console. It
-     * then passes the results to axeCallback if one is defined.
+     * then passes the results to axeCallback if one is defined. Finally, it logs
+     * the violationsHelper tip once after all of the components are rendered.
      * @public
      * @return {Void}
      */
@@ -83,6 +84,7 @@ export function initialize(application) {
             let violation = violations[i];
 
             Ember.Logger.error(`Violation #${i+1}`, violation);
+            window.violationsHelper.push(violation);
 
             let nodes = violation.nodes;
 
@@ -99,6 +101,8 @@ export function initialize(application) {
             Ember.assert('axeCallback should be a function.', typeof this.axeCallback === 'function');
             this.axeCallback(results);
           }
+
+          Ember.run.scheduleOnce('afterRender', window.violationsHelper, window.violationsHelper.logTip);
         });
       }
     }
@@ -109,5 +113,6 @@ export function initialize(application) {
 
 export default {
   name: 'axe-component',
+  after: 'violations-helper',
   initialize
 };

--- a/app/instance-initializers/violations-helper.js
+++ b/app/instance-initializers/violations-helper.js
@@ -1,0 +1,11 @@
+import ViolationsHelper from 'ember-a11y-testing/utils/violations-helper';
+
+export function initialize(application) {
+  window.violationsHelper = new ViolationsHelper();
+}
+
+export default {
+  name: 'violations-helper',
+  before: 'axe-component',
+  initialize
+};

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = {
 
     if (isProductionBuild || isOldEmber) {
       tree = new Funnel(tree, {
-        exclude: [/instance-initializers\/axe-component.js/]
+        exclude: [/instance-initializers\/axe-component|violations-helper.js/]
       });
     }
 

--- a/tests/acceptance/violations-test.js
+++ b/tests/acceptance/violations-test.js
@@ -41,3 +41,28 @@ test('marking DOM nodes with violations', function(assert) {
   visit('/violations');
 
 });
+
+test('violationsHelper set in the global scope', function(assert) {
+
+  // In order for the audit to run, we have to act like we're not in testing
+  Ember.run(function() { Ember.testing = false; });
+
+  visit('/violations');
+
+  let logTipSpy;
+
+  // ensures we set the spy before the 'afterRender' queue
+  Ember.run.once(function() {
+    logTipSpy = sandbox.spy(window.violationsHelper, 'logTip');
+  });
+
+  andThen(() => {
+    assert.equal(window.violationsHelper.count, 2, "Two violations are found in the violationsHelper");
+
+    assert.ok(logTipSpy.calledOnce, "logTip is only called once after all components are rendered and violations logged");
+
+    // Turn testing mode back on to ensure validity of other tests
+    Ember.run(function() { Ember.testing = true; });
+  });
+
+});

--- a/tests/unit/instance-initializers/axe-component-test.js
+++ b/tests/unit/instance-initializers/axe-component-test.js
@@ -132,9 +132,15 @@ test('audit should log any violations found', function(assert) {
   const logSpy = sandbox.spy(Logger, 'error');
   const component = Component.create({});
 
+  // In order for the audit to run, we have to act like we're not in testing
+  Ember.testing = false;
+
   component.audit();
 
   assert.ok(logSpy.calledOnce);
+
+  // Turn testing mode back on to ensure validity of other tests
+  Ember.testing = true;
 });
 
 

--- a/tests/unit/instance-initializers/violations-helper-test.js
+++ b/tests/unit/instance-initializers/violations-helper-test.js
@@ -1,0 +1,22 @@
+/* global sinon */
+import { initialize } from 'dummy/instance-initializers/violations-helper';
+import { module, test } from 'qunit';
+
+let application;
+let sandbox;
+
+module('Unit | Instance Initializer | violations-helper', {
+  beforeEach() {
+    sandbox = sinon.sandbox.create();
+  },
+
+  afterEach() {
+    sandbox.restore();
+  }
+});
+
+test('initializer sets a violationsHelper in the global scope', function(assert) {
+  initialize(application);
+
+  assert.ok(window.violationsHelper);
+});

--- a/tests/unit/utils/violations-helper-test.js
+++ b/tests/unit/utils/violations-helper-test.js
@@ -1,0 +1,104 @@
+/* global sinon */
+import { module, test } from 'qunit';
+import ViolationsHelper from 'ember-a11y-testing/utils/violations-helper';
+import Ember from 'ember';
+
+let sandbox;
+
+module('Unit | Utils | ViolationsHelper', {
+  beforeEach() {
+    sandbox = sinon.sandbox.create();
+  },
+
+  afterEach() {
+    sandbox.restore();
+  }
+});
+
+test('initializes with a violations array', function(assert) {
+  let violationsHelper = new ViolationsHelper();
+  let violationsHelperWithArguments = new ViolationsHelper('error');
+
+  assert.deepEqual(violationsHelper.violations, []);
+  assert.deepEqual(violationsHelperWithArguments.violations, ['error']);
+});
+
+/* Alias methods */
+
+test('count', function(assert) {
+  let violationsHelper = new ViolationsHelper('error');
+
+  assert.equal(violationsHelper.count, 1);
+});
+
+test('first', function(assert) {
+  let violationsHelper = new ViolationsHelper('error', 'failure');
+
+  assert.equal(violationsHelper.first, 'error');
+});
+
+test('last', function(assert) {
+  let violationsHelper = new ViolationsHelper('error', 'failure');
+
+  assert.equal(violationsHelper.last, ['failure']);
+});
+
+test('push', function(assert) {
+  let violationsHelper = new ViolationsHelper();
+  violationsHelper.push('error');
+
+  assert.deepEqual(violationsHelper.violations, ['error']);
+});
+
+/* filterBy */
+
+test('filterBy rule', function(assert) {
+  let colorContrastViolation = { id: 'color-contrast' };
+  let violationsHelper = new ViolationsHelper(colorContrastViolation);
+
+  assert.deepEqual(violationsHelper.filterBy('rule', 'color-contrast'), [colorContrastViolation], "converts 'rule' key to 'id'");
+});
+
+test('filterBy impact', function(assert) {
+  let colorContrastViolation = { id: 'color-contrast', impact: 'critical' };
+  let buttonNameViolation = { id: 'button-name', impact: 'critical' };
+  let violationsHelper = new ViolationsHelper(colorContrastViolation, buttonNameViolation);
+
+  assert.deepEqual(violationsHelper.filterBy('impact', 'critical'), [colorContrastViolation, buttonNameViolation], "returns all violations that match the key-value pair");
+});
+
+test('filterBy node', function(assert) {
+  let sloppyInput = { nodes: [ { target: ['#sloppy-input'] } ] };
+  let violationsHelper = new ViolationsHelper(sloppyInput);
+
+  assert.deepEqual(violationsHelper.filterBy('node', '#sloppy-input'), [sloppyInput], "returns violations attached to the matching node");
+});
+
+
+/* logTip */
+
+test('only logs tip if there are violations', function(assert) {
+  let violationsHelper = new ViolationsHelper();
+  let loggerInfoSpy = sandbox.spy(Ember.Logger, 'info');
+
+  violationsHelper.logTip();
+  assert.ok(!loggerInfoSpy.called, "Nothing is logged if there are no violations");
+
+  violationsHelper.push('violation');
+
+  violationsHelper.logTip();
+  assert.ok(loggerInfoSpy.called);
+});
+
+test('will not log tip more than once', function(assert) {
+  let violationsHelper = new ViolationsHelper('violation');
+  let loggerInfoSpy = sandbox.spy(Ember.Logger, 'info');
+
+  violationsHelper.logTip();
+  assert.ok(loggerInfoSpy.called);
+
+  let firstCallCount = loggerInfoSpy.callCount;
+
+  violationsHelper.logTip();
+  assert.equal(loggerInfoSpy.callCount, firstCallCount, "does not log anymore after the first time");
+});


### PR DESCRIPTION
Util object that exposes some helper methods in the console. Hopefully makes dealing with violations in development a little less messy.

As discussed @nathanhammond 
https://github.com/ember-a11y/ember-a11y-testing/issues/18#issuecomment-231880458