### PR TITLE
Fix parsing of custom violation class names

### DIFF
--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -40,12 +40,13 @@ export function initialize(application) {
     turnAuditOff: false,
 
     /**
-     * An array of classNames to add to the component when a violation occurs.
+     * An array of classNames (or a space-separated string) to add to the component when a violation occurs.
      * If unspecified, the `axe-violation` class is used to apply our default
      * styling
      *
      * @public
-     * @type {Array}
+     * @type {(Array|string)}
+     * @see(https://github.com/ember-a11y/ember-a11y-testing/blob/master/content-for/head-footer.html)
      */
     axeViolationClassNames: ['axe-violation'],
 
@@ -71,7 +72,12 @@ export function initialize(application) {
       if (this.get('tagName') !== '') {
         axe.a11yCheck(this.$(), this.axeOptions, (results) => {
           const violations = results.violations;
-          const violationClassNames = this.get('axeViolationClassNames');
+          let violationClassNames = this.get('axeViolationClassNames');
+
+          if (typeof violationClassNames === 'string') {
+            // support passing as a space-separated string
+            violationClassNames = violationClassNames.trim().split(/\s+/);
+          }
 
           for (let i = 0, l = violations.length; i < l; i++) {
             let violation = violations[i];


### PR DESCRIPTION
I discovered a fun bug with our custom `axeViolationClassNames` functionality:

We’re expecting this to be an Array when we use it in the `axe.a11yCheck` callback, but in the (I think very common) case where someone passes them as a string argument in a component’s template, that’s not quite what happens:

<img width="672" alt="screen shot 2016-07-24 at 12 35 22 am" src="https://cloud.githubusercontent.com/assets/5483853/17082528/bd537744-5136-11e6-9cd8-1a7759941e80.png">
<img width="1249" alt="screen shot 2016-07-24 at 12 38 02 am" src="https://cloud.githubusercontent.com/assets/5483853/17082538/06bc0518-5137-11e6-91c0-a822af216947.png">

This fix for this is just to make sure we check for `axeViolationClassNames` being a string, and if it is, [split it on whitespace]() to make an array element from each word. 

I also took the opportunity to clean up the tests in general while writing a new one for this issue, so you’ll see a few line changes there as well. (The main change is a helper function that allows each test to not have to stub `axe.a11yCheck` manually.)