### PR TITLE
Ensure axe-versions are in sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,5 @@ script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - ember try $EMBER_TRY_SCENARIO test --skip-cleanup
+  - npm install bower
+  - node node-tests/blueprint-tests.js

--- a/blueprints/ember-a11y-testing/index.js
+++ b/blueprints/ember-a11y-testing/index.js
@@ -4,6 +4,6 @@ module.exports = {
   normalizeEntityName: function() { },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('axe-core', '1.1.1');
+    return this.addBowerPackageToProject('axe-core', '~2.0.5');
   }
 };

--- a/node-tests/blueprint-tests.js
+++ b/node-tests/blueprint-tests.js
@@ -1,0 +1,17 @@
+/* jshint node:true */
+'use strict';
+
+var bower = require('bower');
+var assert = require('assert');
+var readFileSync = require('fs').readFileSync;
+
+bower.commands.list().on('end', function(packageInfo) {
+	var axeVersionFromAddon = packageInfo.dependencies['axe-core'].endpoint.target;
+	var blueprintContent = readFileSync('blueprints/ember-a11y-testing/index.js', 'UTF-8');
+
+	assert.ok(
+		blueprintContent.indexOf(axeVersionFromAddon) !== -1,
+		"The axe-core version in blueprint and the one in the addons' bower.json should be the same"
+	);
+
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:each"
+    "test": "ember try:each && node node-tests/blueprint-tests.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Realized that the `axe-core` version in the blueprint is outdated. Fixed it & added a test to make sure we keep the version in the addon and blueprint in sync.