### PR TITLE
CI: Update travis test command syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,6 @@ install:
 script:
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
-  - ember try $EMBER_TRY_SCENARIO test --skip-cleanup
+  - ember try:one $EMBER_TRY_SCENARIO --- ember test --skip-cleanup
   - npm install bower
   - node node-tests/blueprint-tests.js


### PR DESCRIPTION
Currently, our CI builds are throwing a deprecation warning from `ember-try` about the [test command syntax we're using](https://travis-ci.org/ember-a11y/ember-a11y-testing/jobs/152856315#L257). 

This PR just does a bit of future-proofing, and gets `travis.yml` using the [latest recommended style](https://travis-ci.org/ember-a11y/ember-a11y-testing/jobs/152856315#L259).