### PR TITLE
add alpha config to ember-try and update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,13 @@ env:
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
+  - EMBER_TRY_SCENARIO=ember-alpha
 
 matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-alpha
 
 before_install:
   - npm config set spin false

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -52,6 +52,17 @@ module.exports = {
       }
     },
     {
+      name: 'ember-alpha',
+      bower: {
+        dependencies: {
+          'ember': 'components/ember#alpha'
+        },
+        resolutions: {
+          'ember': 'alpha'
+        }
+      }
+    },
+    {
       name: 'ember-lts-2.4',
       bower: {
         dependencies: {


### PR DESCRIPTION
With [Glimmer 2 Alpha builds rolling out](http://emberjs.com/blog/2016/07/29/announcing-the-glimmer-2-alpha.html), there's a good opportunity to start having projects run tests against it in CI. 

This PR adds the proper configuration to ember-try and travis for doing so.