### PR TITLE
Add a11y-audit test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,56 @@ You can see the available options in the [axe-core repo](https://github.com/dequ
 
 _Note:_ the options will stay set, until set to something different.
 
+#### `a11yAudit` Helper
+
+Ember A11y Testing also provides a simple helper to run accessibility audits
+on-demand within your test suite.
+
+For Acceptance tests, the helper is an async test helper so you can use it like
+this:
+
+```javascript
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+
+// ...elided for brevity
+
+test('Some test case', function(assert) {
+  visit('/');
+  a11yAudit();
+  andThen(() => assert.ok(true, 'no a11y errors found!'));
+});
+```
+
+The helper can optionally accept a "context" on which to focus the audit as
+either a selector string or an HTML element. You can also provide a secondary
+parameter to specify axe-core options.
+
+The helper is also able to be used Integration/Unit tests like so:
+
+```javascript
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+
+// ...elided for brevity
+
+test('Some test case', function(assert) {
+  this.render(hbs`{{some-component}}`);
+
+  let axeOptions = {
+    rules: {
+      'button-name': {
+        enabled: false
+      }
+    }
+  };
+  return a11yAudit(this.$(), axeOptions).then(() => {
+    assert.ok(true, 'no a11y errors found!');
+  });
+});
+```
+
+As you can see, the usage for all types of tests is pretty much the same. The
+only real difference is Acceptance tests get automatic async handling.
+
 
 ### Development Usage
 

--- a/addon-test-support/audit.js
+++ b/addon-test-support/audit.js
@@ -1,0 +1,36 @@
+/**
+ * Runs the axe a11y audit on the given context selector and with options.
+ * The context defaults to '#ember-testing-container' if not specified.
+ * The options will fallback to the global axe.ember.testOptions if they're
+ * defined and to the default axe-core options after that.
+ *
+ * @method runA11yAudit
+ * @private
+ */
+function runA11yAudit(contextSelector, auditOptions) {
+  let context = contextSelector || '#ember-testing-container';
+  let options = auditOptions || axe.ember.testOptions || {};
+
+  return axe.run(context, options).then(axe.ember.a11yCheckCallback);
+}
+
+// Register an async helper to use in acceptance tests
+Ember.Test.registerAsyncHelper('a11yAudit', function(app, ...args) {
+  return runA11yAudit(...args);
+});
+
+/**
+ * A wrapper method to run the async a11yAudit test helper if in an acceptance
+ * testing situation, but also supports being used in integration/unit test
+ * scenarios.
+ *
+ * @method a11yAudit
+ * @public
+ */
+export default function a11yAudit(...args) {
+  if (window.a11yAudit) {
+    return window.a11yAudit(...args);
+  }
+
+  return runA11yAudit(...args);
+}

--- a/content-for/test-body-footer.html
+++ b/content-for/test-body-footer.html
@@ -1,9 +1,9 @@
 <script>
   (function() {
-    var runningAudits = 0;
+    var runningAudit = false;
 
     Ember.Test.registerWaiter(function runningAuditWaiter() {
-      return runningAudits === 0;;
+      return !runningAudit;;
     });
 
     /**
@@ -19,7 +19,7 @@
        * @return {Void}
        */
       a11yCheckCallback: function(results) {
-        runningAudits--;
+        runningAudit = false;
 
         var violations = results.violations;
 
@@ -59,7 +59,7 @@
        * @return {Void}
        */
       afterRender: function() {
-        runningAudits++;
+        runningAudit = true;
         axe.a11yCheck('#ember-testing-container', axe.ember.testOptions, axe.ember.a11yCheckCallback);
       },
 

--- a/tests/acceptance/a11y-audit-test.js
+++ b/tests/acceptance/a11y-audit-test.js
@@ -1,0 +1,67 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../../tests/helpers/start-app';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+
+const { run } = Ember;
+
+const SELECTORS = {
+  passingComponent: '[data-test-selector="violations-page__passing-component"]',
+  failingComponent: '[data-test-selector="empty-button"]'
+};
+
+module('Acceptance | a11y-audit', {
+  beforeEach() {
+    axe.ember.turnAxeOff();
+    this.application = startApp();
+  },
+
+  afterEach() {
+    run(this.application, 'destroy');
+    axe.ember.turnAxeOn();
+  }
+});
+
+test('a11yAudit should catch violations as an async helper', function(assert) {
+  visit('/');
+
+  // Since we have `catch` blocks, we need to return these promises to ensure
+  // QUnit waits the whole time(you shouldn't do this normally).
+  return a11yAudit().then(() => {
+    assert.ok(false, 'a11yAudit should have thrown an error on violations');
+  }).catch((e) => {
+    assert.strictEqual(e.message, 'Assertion Failed: The page should have no accessibility violations. Please check the developer console for more details.');
+  });
+});
+
+test('a11yAudit should properly scope to a specified context selector', function(assert) {
+  visit('/');
+
+  a11yAudit(SELECTORS.passingComponent).then(() => {
+    assert.ok(true, 'a11yAudit should not have discovered any issues');
+  });
+
+  // Since we have `catch` blocks, we need to return these promises to ensure
+  // QUnit waits the whole time(you shouldn't do this normally).
+  return a11yAudit(SELECTORS.failingComponent).then(() => {
+    assert.ok(false, 'a11yAudit should have thrown an error on violations');
+  }).catch((e) => {
+    assert.strictEqual(e.message, 'Assertion Failed: The page should have no accessibility violations. Please check the developer console for more details.', 'error message is correct');
+  });
+});
+
+test('a11yAudit can accept an options hash in addition to context', function(assert) {
+  visit('/');
+
+  a11yAudit(SELECTORS.failingComponent, {
+    rules: {
+      'button-name': {
+        enabled: false
+      }
+    }
+  });
+
+  andThen(() => {
+    assert.ok(true, 'no errors should have been found in a11yAudit');
+  });
+});

--- a/tests/integration/helpers/a11y-audit-test.js
+++ b/tests/integration/helpers/a11y-audit-test.js
@@ -1,0 +1,46 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+
+const { Component } = Ember;
+
+// We use a component integration test to verify the behavior of the a11y-audit
+// by rendering a component and then running the audit on it.
+moduleForComponent('component:axe-component', 'Integration | Helper | a11y-audit', {
+  integration: true,
+
+  beforeEach() {
+    this.register('component:axe-component', Component.extend());
+  }
+});
+
+test('a11yAudit runs successfully', function(assert) {
+  this.render(hbs`{{#axe-component}}{{/axe-component}}`);
+
+  return a11yAudit(this.$()).then(() => {
+    assert.ok(true, 'a11yAudit ran and didn\'t find any issues');
+  });
+});
+
+test('a11yAudit catches violations successfully', function(assert) {
+  this.render(hbs`{{#axe-component}}<button></button>{{/axe-component}}`);
+
+  return a11yAudit(this.$()).catch((e) => {
+    assert.strictEqual(e.message, 'Assertion Failed: The page should have no accessibility violations. Please check the developer console for more details.');
+  });
+});
+
+test('a11yAudit can use custom axe options', function(assert) {
+  this.render(hbs`{{#axe-component}}<button></button>{{/axe-component}}`);
+
+  return a11yAudit(this.$(), {
+    rules: {
+      'button-name': {
+        enabled: false
+      }
+    }
+  }).then(() => {
+    assert.ok(true, 'a11yAudit ran and used the custom options');
+  });
+});


### PR DESCRIPTION
This introduces a test helper, `a11yAudit`, to run the axe-core audit on-demand within tests, instead of relying on the default auto-run or component-reopening.

cc @rwjblue @sarbbottam @ember-a11y/core 