### PR TITLE
Upgrade dependencies and improve stability of auto-run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,23 @@ sudo: false
 
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
+    - $HOME/.cache # includes bowers cache
 
 matrix:
   fast_finish: true
 
 before_install:
   - npm config set spin false
-  - npm install -g bower
-  - npm install phantomjs-prebuilt
+  - npm install -g bower phantomjs-prebuilt
+  - bower --version
+  - phantomjs --version
 
 install:
   - npm install
   - bower install
 
 script:
-  # Usually, it's ok to finish the test scenario without reverting
-  #  to the addon's original dependency state, skipping "cleanup".
   - ember try:each
   - npm install bower
   - node node-tests/blueprint-tests.js

--- a/bower.json
+++ b/bower.json
@@ -3,10 +3,7 @@
   "dependencies": {
     "axe-core": "~2.1.7",
     "ember": "release",
-    "ember-cli-shims": "0.1.1",
-    "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0",
-    "sinonjs": "~1.14.1"
+    "ember-cli-shims": "0.1.3"
   },
   "resolutions": {
     "ember": "release"

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -6,9 +6,6 @@ module.exports = {
       bower: {
         dependencies: {
           'ember': '~1.13.0'
-        },
-        resolutions: {
-          'ember': '~1.13.0'
         }
       }
     },
@@ -16,9 +13,6 @@ module.exports = {
       name: 'ember-release',
       bower: {
         dependencies: {
-          'ember': 'components/ember#release'
-        },
-        resolutions: {
           'ember': 'release'
         }
       }
@@ -27,9 +21,6 @@ module.exports = {
       name: 'ember-beta',
       bower: {
         dependencies: {
-          'ember': 'components/ember#beta'
-        },
-        resolutions: {
           'ember': 'beta'
         }
       }
@@ -39,9 +30,6 @@ module.exports = {
       allowedToFail: true,
       bower: {
         dependencies: {
-          'ember': 'components/ember#canary'
-        },
-        resolutions: {
           'ember': 'canary'
         }
       }
@@ -50,9 +38,6 @@ module.exports = {
       name: 'ember-lts-2.4',
       bower: {
         dependencies: {
-          'ember': 'components/ember#lts-2-4'
-        },
-        resolutions: {
           'ember': 'lts-2-4'
         }
       }
@@ -61,9 +46,6 @@ module.exports = {
       name: 'ember-lts-2.8',
       bower: {
         dependencies: {
-          'ember': 'components/ember#lts-2-8'
-        },
-        resolutions: {
           'ember': 'lts-2-8'
         }
       }

--- a/content-for/test-body-footer.html
+++ b/content-for/test-body-footer.html
@@ -2,7 +2,7 @@
   (function() {
     var runningAudits = 0;
 
-    Ember.Test.registerWaiter(function() {
+    Ember.Test.registerWaiter(function runningAuditWaiter() {
       return runningAudits === 0;;
     });
 

--- a/content-for/test-body-footer.html
+++ b/content-for/test-body-footer.html
@@ -1,109 +1,121 @@
 <script>
-  /**
-   * Setup all our functions as an extension to the global axe object. This
-   * ensures their availability while also avoiding a continual pollution of the
-   * global namespace.
-   */
-  axe.ember = {
+  (function() {
+    var runningAudits = 0;
+
+    Ember.Test.registerWaiter(function() {
+      return runningAudits === 0;;
+    });
+
     /**
-     * Processes the results of calling axe.a11yCheck. If there are any
-     * violations, it throws an error and then logs them individually.
-     * @param {Object} results
-     * @return {Void}
+     * Setup all our functions as an extension to the global axe object. This
+     * ensures their availability while also avoiding a continual pollution of the
+     * global namespace.
      */
-    a11yCheckCallback: function(results) {
-      var violations = results.violations;
+    axe.ember = {
+      /**
+       * Processes the results of calling axe.a11yCheck. If there are any
+       * violations, it throws an error and then logs them individually.
+       * @param {Object} results
+       * @return {Void}
+       */
+      a11yCheckCallback: function(results) {
+        runningAudits--;
 
-      if (violations.length) {
-        Ember.Logger.error('ACCESSIBILITY VIOLATIONS: ' + violations.length);
+        var violations = results.violations;
 
-        for (var i = 0, l = violations.length; i < l; i++) {
-          var violation = violations[i];
-          var violationNodes = axe.ember.generateNodesArray(violation.nodes);
+        if (violations.length) {
+          Ember.Logger.error('ACCESSIBILITY VIOLATIONS: ' + violations.length);
 
-          Ember.Logger.warn(violation.impact.toUpperCase() + ': ' + violation.help);
-          Ember.Logger.info('Offending markup (' + violation.nodes.length + ')');
-          Ember.Logger.debug(violationNodes);
-          Ember.Logger.info('Additional info: ' + violation.helpUrl);
-          Ember.Logger.info('-------------------------------------');
+          for (var i = 0, l = violations.length; i < l; i++) {
+            var violation = violations[i];
+            var violationNodes = axe.ember.generateNodesArray(violation.nodes);
+
+            Ember.Logger.warn(violation.impact.toUpperCase() + ': ' + violation.help);
+            Ember.Logger.info('Offending markup (' + violation.nodes.length + ')');
+            Ember.Logger.debug(violationNodes);
+            Ember.Logger.info('Additional info: ' + violation.helpUrl);
+            Ember.Logger.info('-------------------------------------');
+          }
         }
-      }
-      Ember.assert('The page should have no accessibility violations. Please check the developer console for more details.', !violations.length);
-    },
 
-    /**
-     * Takes the violations' nodes param and converts it to
-     * an array that constains only offending markup HTML.
-     * @param {Array} nodes
-     * @return {Array}
-     */
-     generateNodesArray: function(nodes) {
-       return nodes.map(function(node) {
-         return node.html;
-       });
-     },
+        Ember.assert('The page should have no accessibility violations. Please check the developer console for more details.', !violations.length);
+      },
 
-    /**
-     * Used as a callback for afterRender. Simply runs axe.a11yCheck and passes
-     * the results to a11yCheckCallback.
-     * @return {Void}
-     */
-    afterRender: function() {
-      axe.a11yCheck('#ember-testing-container', axe.ember.testOptions, axe.ember.a11yCheckCallback);
-    },
+      /**
+       * Takes the violations' nodes param and converts it to
+       * an array that constains only offending markup HTML.
+       * @param {Array} nodes
+       * @return {Array}
+       */
+      generateNodesArray: function(nodes) {
+        return nodes.map(function(node) {
+          return node.html;
+        });
+      },
 
-    /**
-     * Used as a callback at the beginning of each testing module. It checks
-     * if the test is an acceptance test (based on standard Ember-CLI naming
-     * conventions), and adjust the testing display accordingly.
-     * @param {Object} details
-     * @return {Void}
-     */
-    moduleStart: function(details) {
-      if (~details.name.indexOf('Acceptance')) {
-        axe.ember.turnAxeOn();
-      } else {
+      /**
+       * Used as a callback for afterRender. Simply runs axe.a11yCheck and passes
+       * the results to a11yCheckCallback.
+       * @return {Void}
+       */
+      afterRender: function() {
+        runningAudits++;
+        axe.a11yCheck('#ember-testing-container', axe.ember.testOptions, axe.ember.a11yCheckCallback);
+      },
+
+      /**
+       * Used as a callback at the beginning of each testing module. It checks
+       * if the test is an acceptance test (based on standard Ember-CLI naming
+       * conventions), and adjust the testing display accordingly.
+       * @param {Object} details
+       * @return {Void}
+       */
+      moduleStart: function(details) {
+        if (~details.name.indexOf('Acceptance')) {
+          axe.ember.turnAxeOn();
+        } else {
+          axe.ember.turnAxeOff();
+        }
+      },
+
+      /**
+       * Used as a callback at the end of testing. It ensures the testing display
+       * has been reset to it's original appearance.
+       * @return {Void}
+       */
+      qunitDone: function() {
         axe.ember.turnAxeOff();
-      }
-    },
+      },
 
-    /**
-     * Used as a callback at the end of testing. It ensures the testing display
-     * has been reset to it's original appearance.
-     * @return {Void}
-     */
-    qunitDone: function() {
-      axe.ember.turnAxeOff();
-    },
+      /**
+       * Enables the axe-core tests to run on afterRender and modifies the visual
+       * layout of the testing.
+       * @return {Void}
+       */
+      turnAxeOn: function() {
+        Ember.run.backburner.options.render = { after: axe.ember.afterRender };
+        document.body.classList.add('axe-enabled');
+      },
 
-    /**
-     * Enables the axe-core tests to run on afterRender and modifies the visual
-     * layout of the testing.
-     * @return {Void}
-     */
-    turnAxeOn: function() {
-      Ember.run.backburner.options.render = { after: axe.ember.afterRender };
-      document.body.classList.add('axe-enabled');
-    },
+      /**
+       * Disables the axe-core tests to run on afterRender and restores the
+       * original visual layout of the testing.
+       * @return {Void}
+       */
+      turnAxeOff: function() {
+        Ember.run.backburner.options.render = { after: undefined };
+        document.body.classList.remove('axe-enabled');
+      },
 
-    /**
-     * Disables the axe-core tests to run on afterRender and restores the
-     * original visual layout of the testing.
-     * @return {Void}
-     */
-    turnAxeOff: function() {
-      Ember.run.backburner.options.render = { after: undefined };
-      document.body.classList.remove('axe-enabled');
-    },
+      /**
+       * An object of options to pass into axe.a11yCheck.
+       * @type {Object}
+       */
+      testOptions: undefined
+    };
 
-    /**
-     * An object of options to pass into axe.a11yCheck.
-     * @type {Object}
-     */
-    testOptions: undefined
-  };
-
-  // Register the functions to their appropriate places for testing
-  QUnit.moduleStart(axe.ember.moduleStart);
-  QUnit.done(axe.ember.qunitDone);
+    // Register the functions to their appropriate places for testing
+    QUnit.moduleStart(axe.ember.moduleStart);
+    QUnit.done(axe.ember.qunitDone);
+  }());
 </script>

--- a/package.json
+++ b/package.json
@@ -16,33 +16,34 @@
     "url": "https://github.com/ember-a11y/ember-a11y-testing"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4"
   },
   "author": "Trent Willis <trentmwillis@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.2",
-    "ember-ajax": "^2.0.1",
-    "ember-cli": "2.6.2",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-github-pages": "0.1.2",
-    "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^1.4.0",
-    "ember-cli-release": "0.2.9",
-    "ember-cli-sass": "5.3.1",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-ajax": "^2.4.1",
+    "ember-cli": "2.11.1",
+    "ember-cli-app-version": "^2.0.0",
+    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-github-pages": "^0.1.2",
+    "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-jshint": "^2.0.1",
+    "ember-cli-qunit": "^3.0.1",
+    "ember-cli-release": "^0.2.9",
+    "ember-cli-sass": "^6.1.1",
     "ember-cli-sri": "^2.1.0",
+    "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.5.1",
+    "ember-load-initializers": "^0.6.0",
     "ember-radio-button": "1.0.7",
     "ember-resolver": "^2.0.3",
-    "ember-sinon": "0.5.1",
-    "ember-truth-helpers": "1.2.0",
+    "ember-sinon": "^0.6.0",
+    "ember-truth-helpers": "^1.2.0",
     "loader.js": "^4.0.1"
   },
   "keywords": [
@@ -53,9 +54,9 @@
     "testing"
   ],
   "dependencies": {
-    "broccoli-funnel": "^1.0.1",
-    "ember-cli-babel": "^5.1.6",
-    "ember-cli-version-checker": "^1.1.6"
+    "broccoli-funnel": "^1.1.0",
+    "ember-cli-babel": "^5.2.4",
+    "ember-cli-version-checker": "^1.2.0"
   },
   "ember-addon": {
     "demoURL": "http://ember-a11y.github.io/ember-a11y-testing",

--- a/tests/acceptance/auto-run-test.js
+++ b/tests/acceptance/auto-run-test.js
@@ -37,16 +37,19 @@ test('should run the function when visiting a new route', function(assert) {
 
 test('should run the function whenever a render occurs', function(assert) {
   const callbackStub = sandbox.stub(run.backburner.options.render, 'after');
+  let callCount = 0;
 
-  visit('/').then(() => {
+  visit('/');
 
-    assert.ok(callbackStub.calledOnce);
+  andThen(() => {
+    callCount = callbackStub.callCount;
+    assert.ok(callCount > 0, 'afterRender called at least once for initial visit');
     assert.equal(currentPath(), 'violations');
+  });
 
-    click(`${SELECTORS.passingComponent}`);
+  click(SELECTORS.passingComponent);
 
-    andThen(() => {
-      assert.ok(callbackStub.calledTwice);
-    });
+  andThen(() => {
+    assert.ok(callbackStub.callCount > callCount, 'afterRender called more than before');
   });
 });

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,16 +9,16 @@
 
     {{content-for "head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
     {{content-for "head-footer"}}
   </head>
   <body>
     {{content-for "body"}}
 
-    <script src="assets/vendor.js"></script>
-    <script src="assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/tests/index.html
+++ b/tests/index.html
@@ -10,9 +10,9 @@
     {{content-for "head"}}
     {{content-for "test-head"}}
 
-    <link rel="stylesheet" href="assets/vendor.css">
-    <link rel="stylesheet" href="assets/dummy.css">
-    <link rel="stylesheet" href="assets/test-support.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -21,12 +21,11 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <script src="testem.js" integrity=""></script>
-    <script src="assets/vendor.js"></script>
-    <script src="assets/test-support.js"></script>
-    <script src="assets/dummy.js"></script>
-    <script src="assets/tests.js"></script>
-    <script src="assets/test-loader.js"></script>
+    <script src="/testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/dummy.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}
     {{content-for "test-body-footer"}}


### PR DESCRIPTION
Hoping this cuts down on the Travis flakiness.

Previously, the auto-run feature wasn't using a test waiter or test promises, and thus we had no guarantee that the audit actually finished prior to the test run finishing.