### PR TITLE
Properly report exceptions

### DIFF
--- a/content-for/test-body-footer.html
+++ b/content-for/test-body-footer.html
@@ -19,8 +19,6 @@
        * @return {Void}
        */
       a11yCheckCallback: function(results) {
-        runningAudit = false;
-
         var violations = results.violations;
 
         if (violations.length) {
@@ -60,7 +58,12 @@
        */
       afterRender: function() {
         runningAudit = true;
-        axe.a11yCheck('#ember-testing-container', axe.ember.testOptions, axe.ember.a11yCheckCallback);
+        return axe.run('#ember-testing-container', axe.ember.testOptions)
+          .then(axe.ember.a11yCheckCallback)
+          .catch(Ember.Test.adapter.exception)
+          .then(function() {
+            runningAudit = false;
+          });
       },
 
       /**

--- a/tests/acceptance/auto-run-test.js
+++ b/tests/acceptance/auto-run-test.js
@@ -3,40 +3,42 @@ import { module, test } from 'qunit';
 import startApp from '../../tests/helpers/start-app';
 import sinon from 'sinon';
 
-const { run } = Ember;
+const { Test, run } = Ember;
 
 const SELECTORS = {
   passingComponent: '[data-test-selector="violations-page__passing-component"]'
 };
 
-let application;
-let sandbox;
-
 module('Acceptance | auto-run', {
-  beforeEach: function() {
-    application = startApp();
-    sandbox = sinon.sandbox.create();
+  beforeEach() {
+    this.application = startApp();
+    this.sandbox = sinon.sandbox.create();
   },
 
-  afterEach: function() {
-    sandbox.restore();
-    Ember.run(application, 'destroy');
+  afterEach() {
+    this.sandbox.restore();
+    run(this.application, 'destroy');
   }
 });
 
-test('should run the function when visiting a new route', function(assert) {
-  const callbackStub = sandbox.stub(run.backburner.options.render, 'after');
+test('should run the function when visiting a new route and properly report errors', function(assert) {
+  const callbackSpy = this.sandbox.spy(run.backburner.options.render, 'after');
+  const exceptionStub = this.sandbox.stub(Test.adapter, 'exception');
 
   visit('/');
 
   andThen(() => {
-    assert.ok(callbackStub.calledOnce);
+    assert.ok(callbackSpy.calledOnce);
+
+    assert.ok(exceptionStub.calledOnce);
+    assert.ok(exceptionStub.calledWithMatch(Error));
+
     assert.equal(currentPath(), 'violations');
   });
 });
 
 test('should run the function whenever a render occurs', function(assert) {
-  const callbackStub = sandbox.stub(run.backburner.options.render, 'after');
+  const callbackStub = this.sandbox.stub(run.backburner.options.render, 'after');
   let callCount = 0;
 
   visit('/');

--- a/tests/acceptance/violations-test.js
+++ b/tests/acceptance/violations-test.js
@@ -6,11 +6,15 @@ moduleForAcceptance('Acceptance | violations', {
   beforeEach() {
     // In order for the audit to run, we have to act like we're not in testing
     Ember.testing = false;
+
+    // But we don't want to run the automatic audit
+    axe.ember.turnAxeOff();
   },
 
   afterEach() {
-    // Turn testing mode back on to ensure validity of other tests
+    // Reset everything to ensure validity of other tests
     Ember.testing = true;
+    axe.ember.turnAxeOn();
   }
 });
 

--- a/tests/unit/test-body-footer-test.js
+++ b/tests/unit/test-body-footer-test.js
@@ -1,5 +1,6 @@
 /* global QUnit, axe */
 import Ember from 'ember';
+import RSVP from 'rsvp';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
 
@@ -44,17 +45,17 @@ test('a11yCheckCallback should log any violations and throw an error', function(
 
 /* axe.ember.afterRender */
 
-test('afterRender should run a11yCheck and feed the results to callback', function(assert) {
-  let a11yCheckStub = sandbox.stub(axe, 'a11yCheck');
+test('afterRender should run axe.run and feed the results to callback', function(assert) {
+  let runStub = sandbox.stub(axe, 'run').returns(RSVP.Promise.resolve({ violations: [] }));
 
-  axe.ember.afterRender();
-
-  assert.ok(a11yCheckStub.calledOnce);
-  assert.ok(a11yCheckStub.calledWith('#ember-testing-container', undefined, axe.ember.a11yCheckCallback));
+  return axe.ember.afterRender().then(() => {
+    assert.ok(runStub.calledOnce);
+    assert.ok(runStub.calledWith('#ember-testing-container', undefined));
+  });
 });
 
-test('afterRender should run a11yCheck with options and feed the results to callback', function(assert) {
-  let a11yCheckStub = sandbox.stub(axe, 'a11yCheck');
+test('afterRender should run axe.run with options and feed the results to callback', function(assert) {
+  let runStub = sandbox.stub(axe, 'run').returns(RSVP.Promise.resolve({ violations: [] }));
 
   axe.ember.testOptions = {
     runOnly: {
@@ -63,14 +64,13 @@ test('afterRender should run a11yCheck with options and feed the results to call
       }
   };
 
-  axe.ember.afterRender();
+  return axe.ember.afterRender().then(() => {
+    assert.ok(runStub.calledOnce);
+    assert.ok(runStub.calledWith('#ember-testing-container', axe.ember.testOptions));
 
-  assert.ok(a11yCheckStub.calledOnce);
-  assert.ok(a11yCheckStub.calledWith('#ember-testing-container', axe.ember.testOptions, axe.ember.a11yCheckCallback));
-
-  axe.ember.testOptions = undefined;
+    axe.ember.testOptions = undefined;
+  });
 });
-
 /* axe.ember.moduleStart */
 
 test('moduleStart turns axe on for acceptance tests', function(assert) {


### PR DESCRIPTION
Since axe-core switched to using Promises internally, the exceptions during auto-run were getting swallowed. There is no correct way to hook into the Testing Promise system Ember uses, so we instead simply catch any errors and report them through the test adapter.

This will fix https://github.com/ember-a11y/ember-a11y-testing/issues/47.