### PR TITLE
Include axe-core in all non-prod environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import('vendor/axe-core/axe.js', { type: 'test' });
+    if (app.env !== 'production') {
+      app.import('vendor/axe-core/axe.js');
+    }
   },
 
   treeForVendor: function() {


### PR DESCRIPTION
Fixes #61. Verified by linking locally against the reproduction repo.

This was introduced when moving `axe-core` to `npm` (#58).

cc @abought