### PR TITLE
Allow turnAuditOff to be defined globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,11 +245,13 @@ turnAuditOff: true
 ```
 
 #### Environment Options
-With the exception of `turnAuditOff`, each of the fine-grained component hooks above can instead be defined for ALL components inside of your application's `config/environment.js` file. Simply supply them in a `componentOptions` hash on the `ember-a11y-testing` property of `ENV`.
+
+Each of the fine-grained component hooks above can instead be defined for ALL components inside of your application's `config/environment.js` file. Simply supply them in a `componentOptions` hash on the `ember-a11y-testing` property of `ENV`.
 
 ```javascript
 ENV['ember-a11y-testing'] = {
     componentOptions: {
+      turnAuditOff: false, // Change to true to disable the audit in development
       axeCallback: defaultAxeCallback,
       axeOptions: defaultAxeOptions,
       visualNoiseLevel: 2,

--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -36,6 +36,7 @@ export function initialize() {
   const { componentOptions = {} } = addonConfig;
 
   const {
+    turnAuditOff,
     axeOptions,
     axeCallback,
     visualNoiseLevel,
@@ -64,9 +65,10 @@ export function initialize() {
      * Turns off the accessibility audit during rendering.
      *
      * @public
+     * @default false
      * @type {Boolean}
      */
-    turnAuditOff: false,
+    turnAuditOff: turnAuditOff || false,
 
     /**
      * An array of classNames (or a space-separated string) to add to the component when a violation occurs.


### PR DESCRIPTION
Addressing https://github.com/ember-a11y/ember-a11y-testing/issues/51.

@BrianSipple would appreciate your review since you implemented the original feature.
@ember-a11y/core, if any of you have objections, let me know.