### PR TITLE
Ensure `super` call is bounded

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = {
    * @override
    */
   included: function(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
 
     if (app.tests) {
       app.import('vendor/axe-core/axe.js');


### PR DESCRIPTION
This bit me in a recent 2.12 upgrade, so I'm making sure other addons have the call right