### PR TITLE
feat(a11yAudit): opt in to a11yAudit

### DIFF
--- a/addon-test-support/audit-if.js
+++ b/addon-test-support/audit-if.js
@@ -1,0 +1,30 @@
+import RSVP from 'rsvp';
+import a11yAudit from './audit';
+import utils from './utils';
+
+/**
+ * A method to return the value of queryParameter
+ *
+ * @method getUrlParameter
+ * @private
+ */
+function getUrlParameter(name) {
+    const location = utils.getLocation();
+    const regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+    const results = regex.exec(location.search);
+    return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+};
+
+/**
+ * A wrapper method to run the a11yAudit if desired
+ *
+ * @method a11yAuditIf
+ * @public
+ */
+export default function a11yAuditIf(...args) {
+  if(getUrlParameter('enableA11yAudit') === 'true') {
+    return a11yAudit(...args);
+  }
+
+  return RSVP.resolve(undefined, 'a11y audit not run');
+}

--- a/addon-test-support/utils.js
+++ b/addon-test-support/utils.js
@@ -1,0 +1,5 @@
+export default {
+  getLocation() {
+    return window && window.location;
+  }
+};

--- a/tests/integration/helpers/a11y-audit-if-test.js
+++ b/tests/integration/helpers/a11y-audit-if-test.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import utils from 'ember-a11y-testing/test-support/utils';
+import a11yAuditIf from 'ember-a11y-testing/test-support/audit-if';
+
+const { Component } = Ember;
+
+// We use a component integration test to verify the behavior of the a11y-audit
+// by rendering a component and then running the audit on it.
+moduleForComponent('component:axe-component', 'Integration | Helper | a11y-audit', {
+  integration: true,
+
+  beforeEach() {
+    this.register('component:axe-component', Component.extend());
+  }
+});
+
+test('a11yAuditIf should not execute a11yAudit', function(assert) {
+  this.render(hbs`{{#axe-component}}<button></button>{{/axe-component}}`);
+
+  return a11yAuditIf(this.$()).then(() => {
+    assert.ok(true, 'a11yAuditIf should not run a11yAudit');
+  });
+});
+
+test('a11yAudit should execute a11yAudit if enableA11yAudit=ture is passed as query param', function(assert) {
+  this.render(hbs`{{#axe-component}}<button></button>{{/axe-component}}`);
+  utils.getLocation = function() {
+    return {
+      search: '?enableA11yAudit=true'
+    }
+  }
+  return a11yAuditIf(this.$()).catch((e) => {
+    assert.strictEqual(e.message, 'Assertion Failed: The page should have no accessibility violations. Please check the developer console for more details.');
+  });
+});


### PR DESCRIPTION
Added `a11yAuditIf` method to run `a11yAudit` if `enableA11yAudit=true` is passed as `--query`.

---

**Context**

We want to setup a11y audit as a nightly offline process and don't want to disrupt the current CI/CD pipeline. Since the code changes to accommodate the a11y audit is done in the same repository, we wanted to have a controlled method.

So for the regular acceptance test run `a11yAuditIf()` will function as a `noop` since `--query=enableA11yAudit=true` will not be available.

However for, the dedicated nightly build due to the presence of `--query=enableA11yAudit=true` as part of the test command a11y audit will be performed.