### PR TITLE
Don't include content for production builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = {
    * @override
    */
   contentFor: function(type) {
-    if (~ALLOWED_CONTENT_FOR.indexOf(type)) {
+    if (this.app.env !== 'production' && ~ALLOWED_CONTENT_FOR.indexOf(type)) {
       return fs.readFileSync(path.join(__dirname, 'content-for', type + '.html'));
     }
   },


### PR DESCRIPTION
This stops the style blocks from getting added to the html files on production builds. Can we publish a patch release on merging this?