### PR TITLE
Present information in an easy-to-digest format #18

### DIFF
--- a/addon/utils/violations-helper.js
+++ b/addon/utils/violations-helper.js
@@ -88,7 +88,7 @@ export default class ViolationsHelper {
   }
 
   /**
-   * Logs the tips for using violatonHelper in the console.
+   * Logs the tips for using violationHelper in the console.
    * Only logs if there are existing violations and the tip has not been logged before.
    *
    * @type {Function}

--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -147,7 +147,7 @@ export function initialize() {
             for (let j = 0, k = nodes.length; j < k; j++) {
               nodeData = nodes[j];
 
-              Ember.Logger.error(`[${violation.impact.toUpperCase()}]: ${violation.help} \nOffending markup is: \n${nodeData.html} \n${violation.helpUrl}`, violation);
+              Ember.Logger.error(`[${violation.impact}]: ${violation.help} \nOffending markup is: \n${nodeData.html} \n${violation.helpUrl}`, violation);
               window.violationsHelper.push(violation);
 
               if (nodeData) {

--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -147,7 +147,7 @@ export function initialize() {
             for (let j = 0, k = nodes.length; j < k; j++) {
               nodeData = nodes[j];
 
-              Ember.Logger.error(`[${violation.impact.toUpperCase()}]: ${violation.help} \nOffending markup is: \n${nodeData.html} \n${violation.helpUrl}`);
+              Ember.Logger.error(`[${violation.impact.toUpperCase()}]: ${violation.help} \nOffending markup is: \n${nodeData.html} \n${violation.helpUrl}`, violation);
               window.violationsHelper.push(violation);
 
               if (nodeData) {

--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -142,13 +142,13 @@ export function initialize() {
           for (let i = 0, l = violations.length; i < l; i++) {
             violation = violations[i];
 
-            Ember.Logger.error(`Violation #${i+1}`, violation);
-            window.violationsHelper.push(violation);
-
             nodes = violation.nodes;
 
             for (let j = 0, k = nodes.length; j < k; j++) {
               nodeData = nodes[j];
+
+              Ember.Logger.error(`[${violation.impact.toUpperCase()}]: ${violation.help} \nOffending markup is: \n${nodeData.html} \n${violation.helpUrl}`);
+              window.violationsHelper.push(violation);
 
               if (nodeData) {
                 nodeElem = document.querySelector(nodeData.target.join(','));

--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -144,6 +144,11 @@ export function initialize() {
 
             nodes = violation.nodes;
 
+            if (!nodes) {
+              Ember.Logger.error(`[${violation.impact}]: ${violation.help} \nOffending markup is: \n \n${violation.helpUrl}`, violation);
+              window.violationsHelper.push(violation);
+            }
+
             for (let j = 0, k = nodes.length; j < k; j++) {
               nodeData = nodes[j];
 

--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -144,7 +144,7 @@ export function initialize() {
 
             nodes = violation.nodes;
 
-            if (!nodes) {
+            if (nodes === null || nodes.length == 0) {
               Ember.Logger.error(`[${violation.impact}]: ${violation.help} \nOffending markup is: \n \n${violation.helpUrl}`, violation);
               window.violationsHelper.push(violation);
             }

--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -144,7 +144,7 @@ export function initialize() {
 
             nodes = violation.nodes;
 
-            if (nodes === null || nodes.length == 0) {
+            if (Ember.isEmpty(nodes) || nodes.length === 0) {
               Ember.Logger.error(`[${violation.impact}]: ${violation.help} \nOffending markup is: \n \n${violation.helpUrl}`, violation);
               window.violationsHelper.push(violation);
             }

--- a/tests/acceptance/violations-test.js
+++ b/tests/acceptance/violations-test.js
@@ -20,6 +20,6 @@ test('violationsHelper set in the global scope', function(assert) {
   andThen(() => {
     // This number will vary over time as the document updates and the axe-core
     // library changes, therefore we only care that it is finding violations
-    assert.ok(window.violationsHelper.count > 0, "Violations are found in the violationsHelper");
+    assert.ok(window.violationsHelper.count > 0, 'Violations are found in the violationsHelper');
   });
 });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,9 +1,9 @@
 /* eslint-env node */
-module.exports = function(environment) {
+module.exports = function (environment) {
   var ENV = {
     modulePrefix: 'dummy',
     environment: environment,
-    baseURL: '/',
+    rootURL: '/',
     locationType: 'auto',
     EmberENV: {
       FEATURES: {
@@ -28,7 +28,7 @@ module.exports = function(environment) {
 
   if (environment === 'test') {
     // Testem prefers this...
-    ENV.baseURL = '/';
+    ENV.rootURL = '/';
     ENV.locationType = 'none';
 
     // keep test console output quieter
@@ -44,7 +44,7 @@ module.exports = function(environment) {
    */
   if (environment === 'production' || environment === 'gh-pages') {
     ENV.locationType = 'hash';
-    ENV.baseURL = '/ember-a11y-testing/';
+    ENV.rootURL = '/ember-a11y-testing/';
   }
 
   return ENV;

--- a/tests/integration/instance-initializers/axe-component-test.js
+++ b/tests/integration/instance-initializers/axe-component-test.js
@@ -145,8 +145,7 @@ test('audit should log any violations found if no nodes are found', function(ass
   stubA11yCheck(sandbox, {
     violations: [{
       name: 'test',
-      nodes: [
-      ]
+      nodes: []
     }]
   });
 

--- a/tests/integration/instance-initializers/axe-component-test.js
+++ b/tests/integration/instance-initializers/axe-component-test.js
@@ -122,7 +122,14 @@ test('audit should log any violations found', function(assert) {
   stubA11yCheck(sandbox, {
     violations: [{
       name: 'test',
-      nodes: []
+      nodes: [
+        {
+          target:
+          [
+            '#ember-testing'
+          ]
+        }
+      ]
     }]
   });
 

--- a/tests/integration/instance-initializers/axe-component-test.js
+++ b/tests/integration/instance-initializers/axe-component-test.js
@@ -139,6 +139,22 @@ test('audit should log any violations found', function(assert) {
   assert.ok(logSpy.calledOnce);
 });
 
+test('audit should log any violations found if no nodes are found', function(assert) {
+  initializeViolationsHelper();
+
+  stubA11yCheck(sandbox, {
+    violations: [{
+      name: 'test',
+      nodes: [
+      ]
+    }]
+  });
+
+  const logSpy = sandbox.spy(Logger, 'error');
+  this.render(hbs`{{#axe-component}}{{content}}{{/axe-component}}`);
+
+  assert.ok(logSpy.calledOnce);
+});
 
 test('audit should do nothing if no violations found', function(assert) {
   initializeViolationsHelper();


### PR DESCRIPTION
Addresses issue #18 
* Console logging is  formatted as ` [impact]: [help]. Offending markup is: [nodes.html]`
* Ex: `critical: Form elements must have labels. Offending markup is: <input id="test" type="test">`