### PR TITLE
Package upgrades and locking version of htmlbars-inline-precompile.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-eslint": "^3.0.2",
     "ember-cli-github-pages": "^0.1.2",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "0.3.11",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.0.1",
     "ember-cli-release": "^0.2.9",
@@ -54,7 +54,7 @@
     "testing"
   ],
   "dependencies": {
-    "axe-core": "^2.2.1",
+    "axe-core": "^2.4.2",
     "broccoli-funnel": "^1.1.0",
     "ember-cli-babel": "^5.2.4",
     "ember-cli-version-checker": "^1.2.0"


### PR DESCRIPTION
- Enforcing installation of axe-core 2.4.2 or greater due to security issues.
- Locked ember-cli-htmlbars-inline-precompile to 0.3.11. Versions greater than 0.3.11 (0.3.12 and 0.3.13) are causing template compilation to fail (hence all pull requests since last updates were failing).

@trentmwillis 