### PR TITLE
Add a helper for visit-and-audit

### DIFF
--- a/addon-test-support/visit-and-audit.js
+++ b/addon-test-support/visit-and-audit.js
@@ -1,0 +1,15 @@
+import { visit as visitHelper } from '@ember/test-helpers';
+import a11yAudit from './audit';
+
+/**
+ * A wrapper method to run the a11yAudit if desired
+ *
+ * @method a11yAuditIf
+ * @public
+ */
+export default function visitAndAudit(path, axeOptions) {
+  let visit = window.visit || visitHelper;
+  return visit(path).then(() => {
+    return a11yAudit(axeOptions);
+  });
+}

--- a/tests/acceptance/visit-and-audit-test.js
+++ b/tests/acceptance/visit-and-audit-test.js
@@ -1,0 +1,23 @@
+import { run } from '@ember/runloop';
+import { module, test } from 'qunit';
+import startApp from '../../tests/helpers/start-app';
+import visitAndAudit from 'ember-a11y-testing/test-support/visit-and-audit';
+
+module('Acceptance | visit-and-audit', {
+  beforeEach() {
+    this.application = startApp();
+  },
+
+  afterEach() {
+    run(this.application, 'destroy');
+  }
+});
+
+test('visitAndAudit should visit and audit a page', function(assert) {
+  let expectedErrorMessage = "Assertion Failed: The page should have no accessibility violations. Please check the developer console for more details.";
+  visitAndAudit('/').then(() => {
+    assert.ok(false, 'audit was not run');
+  }).catch((error) => {
+    assert.equal(error.message, expectedErrorMessage);
+  });
+});


### PR DESCRIPTION
This is a request for feedback on a new helper. After the details are decided, I'll update the readme to reflect its usage.

This PR adds a new helper called `visitAndAudit`. It simply visits a page, then audits it. This allows you to more easily always run an audit in acceptance tests, for example.

I tried using this in an app that uses the newer `import { visit } from '@ember/test-helpers';` to get a reference to visit, which works. I'm not sure if this is the best way to support multiple ways to get `visit` or not.

---

This works in a consuming app by:

```
import visit from 'ember-a11y-testing/test-support/visit-and-audit';
```

Then using `visit` (or whatever you want to call it) like normal:

```
visit('/products');
```

Or with aXe options:

```
visit('/products', axeOptions);
```

---

Resolves: https://github.com/ember-a11y/ember-a11y-testing/issues/102
