### PR TITLE
Axe-core v3.1.2 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: required
 dist: trusty

--- a/addon/services/concurrent-axe.js
+++ b/addon/services/concurrent-axe.js
@@ -1,0 +1,41 @@
+/* global axe */
+import Service from '@ember/service';
+import { next } from '@ember/runloop';
+
+export default Service.extend({
+  init() {
+    this._super(...arguments);
+    this._timer = null;
+    this._queue = [];
+  },
+
+  /**
+   * Axe v3 contains a concurrency issue which breaks the component auditing feature.
+   * This service defers axe.run calls on onto the next loop so that concurrent 
+   * axe executions do not occur.
+   *
+   * @see(https://github.com/dequelabs/axe-core/issues/1041)
+   * @public
+   * @param {HTMLElement} element axe context
+   * @param {Object} options axe configuration options
+   * @param {Function} callback axe audit callback
+   * @return {Void}
+   */
+  run(element, options, callback) {
+    if (this._timer) {
+      this._queue.push(arguments);
+    } else {
+      this._timer = next(() => {
+        if (element && element.parentNode) {
+          axe.run(element, options, callback);
+        }
+
+        this._timer = null;
+
+        if (this._queue.length) {
+          this.run(...this._queue.shift());
+        }
+      });
+    }
+  }
+});

--- a/app/services/concurrent-axe.js
+++ b/app/services/concurrent-axe.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-a11y-testing/services/concurrent-axe';

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "axe-core": "^2.6.1",
+    "axe-core": "^3.1.2",
     "broccoli-funnel": "^2.0.1",
     "ember-cli-babel": "^6.8.2",
     "ember-cli-version-checker": "^2.1.0",

--- a/tests/acceptance/a11y-audit-test.js
+++ b/tests/acceptance/a11y-audit-test.js
@@ -93,7 +93,7 @@ test('a11yAudit can accept an options hash as a single argument', function(asser
   a11yAudit({
     runOnly: {
       type: "rule",
-      values: []
+      values: ["accesskeys"]
     }
   });
 

--- a/tests/dummy/app/components/x-text-input.js
+++ b/tests/dummy/app/components/x-text-input.js
@@ -2,6 +2,5 @@ import Component from '@ember/component';
 
 
 export default Component.extend({
-  classNames: ['c-text-input'],
-  tagName: 'input',
+  classNames: ['c-text-input']
 });

--- a/tests/dummy/app/templates/components/x-text-input.hbs
+++ b/tests/dummy/app/templates/components/x-text-input.hbs
@@ -1,6 +1,6 @@
 <input
   class="c-text-input__input"
-  id={{id}}
+  id={{inputId}}
   type="text"
   placeholder={{placeholder}}
   value={{value}}>

--- a/tests/dummy/app/templates/violations.hbs
+++ b/tests/dummy/app/templates/violations.hbs
@@ -55,7 +55,7 @@
           value=3
           name="noise-level"
           class="c-radio-track__item-input"
-          radioId="noise-level-3"
+          id="noise-level-3"
           changed="updateCurrentNoiseLevel"
         }}
         <span class="c-radio-track__item-node">Level 3</span>
@@ -74,7 +74,7 @@
   <ul class="p-violations__grid u-fill-width u-relative">
 
     {{! Empty button }}
-    {{#violations-grid-item class="p-violations__grid-item" title="Button without title"}}
+    {{#violations-grid-item class="p-violations__grid-item" title="Button without title" turnAuditOff=true}}
 
       {{x-button
         id="violations__empty-button"
@@ -85,12 +85,12 @@
     {{/violations-grid-item}}
 
     {{! Labeless text input }}
-    {{#violations-grid-item class="p-violations__grid-item" title="Input without label"}}
-      {{x-text-input id="violations__labeless-input" data-test-selector="labeless-text-input" visualNoiseLevel=model.currentNoiseLevel}}
+    {{#violations-grid-item class="p-violations__grid-item" title="Input without label" turnAuditOff=true}}
+      {{x-text-input inputId="violations__labeless-input" data-test-selector="labeless-text-input" visualNoiseLevel=model.currentNoiseLevel}}
     {{/violations-grid-item}}
 
     {{! Poorly Contrasting Text color }}
-    {{#violations-grid-item class="p-violations__grid-item" title="Poorly Contrasting Text Color"}}
+    {{#violations-grid-item class="p-violations__grid-item" title="Poorly Contrasting Text Color" turnAuditOff=true}}
       {{#x-paragraph
         class="p-violations__grid-item-content--low-contrast-text"
         data-test-selector="labeless-text-input"
@@ -101,19 +101,19 @@
     {{/violations-grid-item}}
 
     {{! Usage of the <blink> element }}
-    {{#violations-grid-item class="p-violations__grid-item" title="Non-standard HTML elements"}}
+    {{#violations-grid-item class="p-violations__grid-item" title="Non-standard HTML elements" turnAuditOff=true}}
       {{#x-paragraph id="violations__non-standard-html" data-test-selector="paragraph-with-blink-tag" visualNoiseLevel=model.currentNoiseLevel}}
         Friends don't let friends use <code>&lt;blink&gt; tags</code>, <blink>like this one!</blink>
       {{/x-paragraph}}
     {{/violations-grid-item}}
 
     {{! <img> tags without `alt` text }}
-    {{#violations-grid-item class="p-violations__grid-item" title="<img> Tags without `alt` attributes"}}
+    {{#violations-grid-item class="p-violations__grid-item" title="<img> Tags without `alt` attributes" turnAuditOff=true}}
       {{x-image class="u-fill" id="violations__img-without-alt" src="assets/img/empire-state-building-moonlight.png" visualNoiseLevel=model.currentNoiseLevel}}
     {{/violations-grid-item}}
 
     {{! Related radio elements without a `<radiogroup>` }}
-    {{#violations-grid-item class="p-violations__grid-item" title="Ungrouped radio inputs with a shared name"}}
+    {{#violations-grid-item class="p-violations__grid-item" title="Ungrouped radio inputs with a shared name" turnAuditOff=true}}
 
       {{!--
         💡 PRO TIP: In lieu of a <radiogroup>, a containing <fieldset>

--- a/tests/integration/instance-initializers/axe-component-test.js
+++ b/tests/integration/instance-initializers/axe-component-test.js
@@ -8,6 +8,7 @@ import {
 } from 'dummy/instance-initializers/violations-helper';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import wait from 'ember-test-helpers/wait';
 
 const {
   Logger
@@ -41,8 +42,8 @@ function setupDOMNode(id = ID_TEST_DOM_NODE, tagName = 'div') {
 }
 
 function stubA11yCheck(sandbox, callbackPayload) {
-  sandbox.stub(axe, 'a11yCheck').callsFake(function (el, options, callback) {
-    callback(callbackPayload);
+  sandbox.stub(axe, 'run').callsFake(function(el, options, callback) {
+    callback(undefined, callbackPayload);
   });
 }
 
@@ -58,6 +59,26 @@ function stubViolationOnDOMNode(sandbox, selector) {
       ]
     }]
   });
+}
+
+function setupVisualNoiseLevel(visualNoiseLevel) {
+  initializeViolationsHelper();
+  stubViolationOnDOMNode(sandbox, `#${ID_TEST_DOM_NODE}`);
+  const dummyDOMNode = setupDOMNode(ID_TEST_DOM_NODE);
+
+  this.set('visualNoiseLevel', visualNoiseLevel);
+  this.render(hbs`{{axe-component visualNoiseLevel=visualNoiseLevel}}`);
+
+  return dummyDOMNode;
+}
+
+function assertVisualNoiseLevel(assert, visualNoiseLevel, dummyDOMNode) {
+  [1, 2, 3].forEach((_noiseLevel) => {
+    const assertFunc = (_noiseLevel === visualNoiseLevel) ? 'ok' : 'notOk';
+    assert[assertFunc](dummyDOMNode.classList.contains(VIOLATION_CLASS_MAP[`LEVEL_${_noiseLevel}`], `assert ${assertFunc} for level ${_noiseLevel}`));
+  });
+
+  dummyDOMNode.remove();
 }
 
 // We use a component integration test to verify the behavior of axe-component
@@ -148,7 +169,9 @@ test('audit should log any violations found', function(assert) {
   const logSpy = sandbox.spy(Logger, 'error');
   this.render(hbs`{{#axe-component}}{{content}}{{/axe-component}}`);
 
-  assert.ok(logSpy.calledOnce);
+  return wait().then(() => {
+    assert.ok(logSpy.calledOnce);
+  });
 });
 
 test('audit should log any violations found if no nodes are found', function(assert) {
@@ -166,8 +189,7 @@ test('audit should log any violations found if no nodes are found', function(ass
 
   const logSpy = sandbox.spy(Logger, 'error');
   this.render(hbs`{{#axe-component}}{{content}}{{/axe-component}}`);
-
-  assert.ok(logSpy.calledOnce);
+  return wait().then(() => assert.ok(logSpy.calledOnce));
 });
 
 test('audit should do nothing if no violations found', function(assert) {
@@ -193,50 +215,56 @@ test('axeCallback receives the results of the audit', function(assert) {
   this.set('axeCallbackSpy', axeCallbackSpy);
   this.render(hbs`{{#axe-component axeCallback=axeCallbackSpy}}{{content}}{{/axe-component}}`);
 
-  assert.ok(axeCallbackSpy.calledOnce);
-  assert.ok(axeCallbackSpy.calledWith(results));
+  return wait().then(() => {
+    assert.ok(axeCallbackSpy.calledOnce);
+    assert.ok(axeCallbackSpy.calledWith(results));
+  });
 });
 
 test('axeCallback throws an error if it is not a function', function(assert) {
   const results = { violations: [] };
-
-  sandbox.stub(axe, 'a11yCheck').callsFake(function (el, options, callback) {
-    assert.throws(() => callback(results) , /axeCallback should be a function./);
+  const a11yCheckStub = sandbox.stub(axe, 'run').callsFake(function(el, options, callback) {
+    assert.throws(() => callback(undefined, results), /axeCallback should be a function./);
   });
 
   this.render(hbs`{{#axe-component axeCallback='axeCallbackSpy'}}{{content}}{{/axe-component}}`);
+
+  return wait().then(() => assert.ok(a11yCheckStub.calledOnce));
 });
 
 /* Component.axeOptions */
 
 test('axeOptions are passed in as the second param to a11yCheck', function(assert) {
-  const a11yCheckStub = sandbox.stub(axe, 'a11yCheck');
+  const a11yCheckStub = sandbox.stub(axe, 'run');
   const axeOptions = { test: 'test' };
   this.set('axeOptions', axeOptions);
   this.render(hbs`{{axe-component class="component" axeOptions=axeOptions}}`);
 
-  assert.ok(a11yCheckStub.calledOnce);
-  assert.ok(a11yCheckStub.calledWith(sinon.match.any, axeOptions));
+  return wait().then(() => {
+    assert.ok(a11yCheckStub.calledOnce);
+    assert.ok(a11yCheckStub.calledWith(sinon.match.any, axeOptions));
+  });
 });
 
-test('#violationClasses is computed from the current `visualNoiseLevel`', function(assert) {
-  initializeViolationsHelper();
+test('#violationClass is computed from `visualNoiseLevel` 1', function(assert) {
+  const visualNoiseLevel = 1;
+  const dummyDOMNode = setupVisualNoiseLevel.call(this, visualNoiseLevel);
 
-  stubViolationOnDOMNode(sandbox, `#${ID_TEST_DOM_NODE}`);
+  return wait().then(() => assertVisualNoiseLevel(assert, visualNoiseLevel, dummyDOMNode));
+});
 
-  const dummyDOMNode = setupDOMNode(ID_TEST_DOM_NODE);
+test('#violationClass is computed from `visualNoiseLevel` 2', function(assert) {
+  const visualNoiseLevel = 2;
+  const dummyDOMNode = setupVisualNoiseLevel.call(this, visualNoiseLevel);
 
-  [1, 2, 3].forEach((currentNoiseLevel) => {
-    this.set('visualNoiseLevel', currentNoiseLevel);
-    this.render(hbs`{{axe-component visualNoiseLevel=visualNoiseLevel}}`);
+  return wait().then(() => assertVisualNoiseLevel(assert, visualNoiseLevel, dummyDOMNode));
+});
 
-    [1, 2, 3].forEach((_noiseLevel) => {
-      const assertFunc = (_noiseLevel === currentNoiseLevel) ? 'ok' : 'notOk';
-      assert[assertFunc](dummyDOMNode.classList.contains(VIOLATION_CLASS_MAP[`LEVEL_${_noiseLevel}`], `assert ${assertFunc} for level ${_noiseLevel}`));
-    });
-  });
+test('#violationClass is computed from `visualNoiseLevel` 3', function(assert) {
+  const visualNoiseLevel = 3;
+  const dummyDOMNode = setupVisualNoiseLevel.call(this, visualNoiseLevel);
 
-  dummyDOMNode.remove();
+  return wait().then(() => assertVisualNoiseLevel(assert, visualNoiseLevel, dummyDOMNode));
 });
 
 test('`axeViolationClassNames` can be passed as a space-separated string (to aid template usage)', function (assert) {
@@ -249,9 +277,10 @@ test('`axeViolationClassNames` can be passed as a space-separated string (to aid
   this.set('axeViolationClassNames', 'spark 🐋   foo  ');
   this.render(hbs`{{axe-component axeViolationClassNames=axeViolationClassNames}}`);
 
-  assert.deepEqual([].slice.call(dummyDOMNode.classList), ['spark', '🐋', 'foo']);
-
-  dummyDOMNode.remove();
+  return wait().then(() => {
+    assert.deepEqual([].slice.call(dummyDOMNode.classList), ['spark', '🐋', 'foo']);
+    dummyDOMNode.remove();
+  });
 });
 
 test('#violationClasses will always give precedence to a `axeViolationClassNames`, if it is set', function (assert) {
@@ -265,15 +294,17 @@ test('#violationClasses will always give precedence to a `axeViolationClassNames
   this.set('axeViolationClassNames', axeViolationClassNames);
   this.render(hbs`{{axe-component axeViolationClassNames=axeViolationClassNames}}`);
 
-  axeViolationClassNames.forEach(className => {
-   assert.ok(dummyDOMNode.classList.contains(className));
-  });
+  return wait().then(() => {
+    axeViolationClassNames.forEach(className => {
+      assert.ok(dummyDOMNode.classList.contains(className));
+    });
 
-  [1, 2, 3].forEach(noiseLevel => {
-   assert.notOk(dummyDOMNode.classList.contains(VIOLATION_CLASS_MAP[`LEVEL_${noiseLevel}`]));
-  });
+    [1, 2, 3].forEach(noiseLevel => {
+      assert.notOk(dummyDOMNode.classList.contains(VIOLATION_CLASS_MAP[`LEVEL_${noiseLevel}`]));
+    });
 
-  dummyDOMNode.remove();
+    dummyDOMNode.remove();
+  });
 });
 
 test('using default class names for violations when no `axeViolationClassNames` is provided', function (assert) {
@@ -285,9 +316,10 @@ test('using default class names for violations when no `axeViolationClassNames` 
 
   this.render(hbs`{{axe-component}}`);
 
-  assert.ok(dummyDOMNode.classList.contains(VIOLATION_CLASS_MAP.LEVEL_1));
-
-  dummyDOMNode.remove();
+  return wait().then(() => {
+    assert.ok(dummyDOMNode.classList.contains(VIOLATION_CLASS_MAP.LEVEL_1));
+    dummyDOMNode.remove();
+  });
 });
 
 test(`smartly detects replaced elements and applies a special \`border-box\` style instead
@@ -302,8 +334,10 @@ of the styles from the current setting`, function(assert) {
   this.set('axeViolationClassNames', [customViolationClass]);
   this.render(hbs`{{axe-component axeViolationClassNames=axeViolationClassNames}}`);
 
-  assert.ok(dummyDOMNode.classList.contains(VIOLATION_CLASS_MAP.REPLACED_ELEMENT));
-  assert.notOk(dummyDOMNode.classList.contains(customViolationClass));
+  return wait().then(() => {
+    assert.ok(dummyDOMNode.classList.contains(VIOLATION_CLASS_MAP.REPLACED_ELEMENT));
+    assert.notOk(dummyDOMNode.classList.contains(customViolationClass));
 
-  dummyDOMNode.remove();
+    dummyDOMNode.remove();
+  })
 });

--- a/tests/unit/services/concurrent-axe-test.js
+++ b/tests/unit/services/concurrent-axe-test.js
@@ -1,0 +1,73 @@
+/* global sinon, axe */
+import { moduleFor, test } from 'ember-qunit';
+import wait from 'ember-test-helpers/wait';
+
+function setupDOMNode() {
+  const node = document.createElement('div');
+  document.body.appendChild(node);
+  return node;
+}
+
+moduleFor('service:concurrent-axe', 'Unit | Service | concurrent axe', {
+  before() {
+    this.testOptions = { test: 'test' };
+    this.testCallback = function(){};
+  },
+  beforeEach() {
+    this.sandbox = sinon.sandbox.create();
+    this.axeRunStub = this.sandbox.stub(axe, 'run');
+    this.testNode = setupDOMNode();
+  },
+  afterEach() {
+    this.sandbox.restore();
+    this.axeRunStub = null;
+    this.testNode.remove();
+  }
+});
+
+test('service calls axe.run with the correct arguments', function(assert) {
+  assert.expect(1);
+
+  this.subject().run(this.testNode, this.testOptions, this.testCallback);
+
+  return wait().then(() => {
+    assert.ok(this.axeRunStub.withArgs(this.testNode, this.testOptions, this.testCallback).calledOnce, 'called once with all arguments');
+  });
+});
+
+test('all concurrent axe.run calls are executed', function(assert) {
+  assert.expect(5);
+
+  const service = this.subject();
+
+  for (let i=0; i<3; i++) {
+    service.run(this.testNode, this.testOptions, this.testCallback);
+  }
+
+  assert.equal(service._queue.length, 2, 'subsequent calls are placed in the queue');
+  assert.ok(service._timer, 'subsequent calls are scheduled for the next run loop');
+
+  return wait().then(() => {
+    assert.ok(this.axeRunStub.calledThrice, 'axe.run is called thrice');
+    assert.equal(service._queue.length, 0, 'queue is cleared');
+    assert.notOk(service._timer, 'timer is cleared');
+  });
+});
+
+test('axe does not audit invalid DOM node', function(assert) {
+  assert.expect(1);
+
+  const service = this.subject();
+  const div = document.createElement('div');
+
+  service.run(undefined, this.testOptions, this.testCallback);
+  service.run({}, this.testOptions, this.testCallback);
+  service.run(div, this.testOptions, this.testCallback);
+
+  this.testNode.remove();
+  service.run(this.testNode, this.testOptions, this.testCallback);
+
+  return wait().then(() => {
+    assert.ok(this.axeRunStub.notCalled, 'axe.run is not called');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,9 +325,9 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
-axe-core@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.6.1.tgz#28772c4f76966d373acda35b9a409299dc00d1b5"
+axe-core@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.1.2.tgz#ca0aff897ebefca7552f97859dc1217c06c4f9e6"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"


### PR DESCRIPTION
There have been quite a number of axe-core updates since v2.6.1, including numerous bug fixes, additional rules and rule updates, and performance optimizations. As such, it is imperative that an organization getting started with accessibility testing is able to take advantage of new features provided in the latest release of axe-core.

This pull request facilitates the axe-core version upgrade to 3.1.2. Axe-component.js has been updated to use the newer axe.run API method (a11yCheck has been deprecated), and updated the callback function signature (first argument is now an error object, second argument is the audit result). Related tests have also be updated to reflect these changes.

One particular aspect to take note related to axe-core v3, is that concurrent axe calls, such as those that are made in the component audit, result in numerous exceptions as detailed under https://github.com/dequelabs/axe-core/issues/1041. I've created a new service (concurrent-axe.js) which mitigates the issue by deferring subsequent axe.run calls. Fortunately, this issue does not occur when axe is run from within tests.

I've also fixed the demo page, which didn't seem to properly update the UI with its corresponding visual noise level. The issue was occurring due to the fact that the violations-grid-item component was also executing an axe audit on its content, which in turn override the nested component's visuals. This was easily mitigated by disabling audit on the violations-grid-item component. Additionally, the "Level 3" checkbox was broken due to incorrect ID assignment.

I've verified that all changes pass tests and demo page works as expected.

![No Visual Noise](https://user-images.githubusercontent.com/945868/45972491-b5ec0400-bff0-11e8-8cc9-ef80b01afb33.png)
![Visual Noise Level 1](https://user-images.githubusercontent.com/945868/45972505-bedcd580-bff0-11e8-9177-1c9595e8df8b.png)
![Visual Noise Level 2](https://user-images.githubusercontent.com/945868/45972516-c8fed400-bff0-11e8-9b17-8c2d19054394.png)
![Visual Noise Level 3](https://user-images.githubusercontent.com/945868/45972518-cd2af180-bff0-11e8-9582-ebc28aa5b853.png)
