### PR TITLE
Fix services for engines, add option to exclude axe-core for visual component audit feature

### DIFF
--- a/addon/utils/concurrent-axe.js
+++ b/addon/utils/concurrent-axe.js
@@ -1,13 +1,11 @@
 /* global axe */
-import Service from '@ember/service';
 import { next } from '@ember/runloop';
 
-export default Service.extend({
-  init() {
-    this._super(...arguments);
+export class ConcurrentAxe {
+  constructor() {
     this._timer = null;
     this._queue = [];
-  },
+  }
 
   /**
    * Axe v3 contains a concurrency issue which breaks the component auditing feature.
@@ -38,4 +36,6 @@ export default Service.extend({
       });
     }
   }
-});
+}
+
+export default new ConcurrentAxe();

--- a/app/services/concurrent-axe.js
+++ b/app/services/concurrent-axe.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-a11y-testing/services/concurrent-axe';

--- a/index.js
+++ b/index.js
@@ -20,10 +20,15 @@ module.exports = {
    * @override
    */
   included: function(app) {
+    var config = this.project.config();
+    var options = (config[this.name] && config[this.name].componentOptions) || {};
+    var isComponentAuditOff = options.turnAuditOff || false;
+    var shouldExcludeAxeCore = isComponentAuditOff && options.excludeAxeCore;
+
     this._super.included.apply(this, arguments);
 
     if (app.tests) {
-      app.import('vendor/axe-core/axe.js');
+      app.import('vendor/axe-core/axe.js', shouldExcludeAxeCore ? { type: 'test' } : undefined);
     }
   },
 

--- a/tests/unit/utils/concurrent-axe-test.js
+++ b/tests/unit/utils/concurrent-axe-test.js
@@ -1,6 +1,7 @@
 /* global sinon, axe */
-import { moduleFor, test } from 'ember-qunit';
+import { module, test } from 'ember-qunit';
 import wait from 'ember-test-helpers/wait';
+import { ConcurrentAxe } from 'ember-a11y-testing/utils/concurrent-axe';
 
 function setupDOMNode() {
   const node = document.createElement('div');
@@ -8,12 +9,13 @@ function setupDOMNode() {
   return node;
 }
 
-moduleFor('service:concurrent-axe', 'Unit | Service | concurrent axe', {
+module('Unit | Utils | ConcurrentAxe', {
   before() {
     this.testOptions = { test: 'test' };
     this.testCallback = function(){};
   },
   beforeEach() {
+    this.subject = new ConcurrentAxe();
     this.sandbox = sinon.sandbox.create();
     this.axeRunStub = this.sandbox.stub(axe, 'run');
     this.testNode = setupDOMNode();
@@ -25,10 +27,10 @@ moduleFor('service:concurrent-axe', 'Unit | Service | concurrent axe', {
   }
 });
 
-test('service calls axe.run with the correct arguments', function(assert) {
+test('util calls axe.run with the correct arguments', function(assert) {
   assert.expect(1);
 
-  this.subject().run(this.testNode, this.testOptions, this.testCallback);
+  this.subject.run(this.testNode, this.testOptions, this.testCallback);
 
   return wait().then(() => {
     assert.ok(this.axeRunStub.withArgs(this.testNode, this.testOptions, this.testCallback).calledOnce, 'called once with all arguments');
@@ -38,34 +40,31 @@ test('service calls axe.run with the correct arguments', function(assert) {
 test('all concurrent axe.run calls are executed', function(assert) {
   assert.expect(5);
 
-  const service = this.subject();
-
   for (let i=0; i<3; i++) {
-    service.run(this.testNode, this.testOptions, this.testCallback);
+    this.subject.run(this.testNode, this.testOptions, this.testCallback);
   }
 
-  assert.equal(service._queue.length, 2, 'subsequent calls are placed in the queue');
-  assert.ok(service._timer, 'subsequent calls are scheduled for the next run loop');
+  assert.equal(this.subject._queue.length, 2, 'subsequent calls are placed in the queue');
+  assert.ok(this.subject._timer, 'subsequent calls are scheduled for the next run loop');
 
   return wait().then(() => {
     assert.ok(this.axeRunStub.calledThrice, 'axe.run is called thrice');
-    assert.equal(service._queue.length, 0, 'queue is cleared');
-    assert.notOk(service._timer, 'timer is cleared');
+    assert.equal(this.subject._queue.length, 0, 'queue is cleared');
+    assert.notOk(this.subject._timer, 'timer is cleared');
   });
 });
 
 test('axe does not audit invalid DOM node', function(assert) {
   assert.expect(1);
 
-  const service = this.subject();
   const div = document.createElement('div');
 
-  service.run(undefined, this.testOptions, this.testCallback);
-  service.run({}, this.testOptions, this.testCallback);
-  service.run(div, this.testOptions, this.testCallback);
+  this.subject.run(undefined, this.testOptions, this.testCallback);
+  this.subject.run({}, this.testOptions, this.testCallback);
+  this.subject.run(div, this.testOptions, this.testCallback);
 
   this.testNode.remove();
-  service.run(this.testNode, this.testOptions, this.testCallback);
+  this.subject.run(this.testNode, this.testOptions, this.testCallback);
 
   return wait().then(() => {
     assert.ok(this.axeRunStub.notCalled, 'axe.run is not called');


### PR DESCRIPTION
Using a [service](https://github.com/ember-a11y/ember-a11y-testing/blob/master/addon/services/concurrent-axe.js) to mitigate the [aXe concurrency issue](https://github.com/ember-a11y/ember-a11y-testing/blob/master/addon/services/concurrent-axe.js) proved to be problematic for apps utilizing Ember engines, as the service needs to be explicitly defined as a dependency for each engine. This a bit too much overhead, especially for apps that don't utilize the visual component audit feature. As a fix, I have changed the service to a simple class, as there's no stateful information being stored in the service anyway. This is a much cleaner approach and removes the overhead of explicit dependency declarations.

We've also encountered a use case where we need to exclude axe-core from development builds (only required during testing). Similarly, for those not readily utilizing the visual component audit feature, including axe-core and modifying the Component class is a bit too much overhead. As such, I've added a new option for excluding axe-core if the visual component audit feature isn't being utilized.
