### PR TITLE
Remove jQuery from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ test('Some test case', function(assert) {
       }
     }
   };
-  return a11yAudit(this.$(), axeOptions).then(() => {
+  return a11yAudit(this.element, axeOptions).then(() => {
     assert.ok(true, 'no a11y errors found!');
   });
 });


### PR DESCRIPTION
Implement #111 where `jQuery` is removed from `README`.