### PR TITLE
Fixes #113

### DIFF
--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -45,7 +45,7 @@ export function initialize() {
   const {
     turnAuditOff: configuredTurnAuditOff,
     excludeAxeCore,
-    axeOptions,
+    axeOptions = {},
     axeCallback,
     visualNoiseLevel: configuredVisualNoiseLevel,
     axeViolationClassNames: configuredAxeViolationClassNames
@@ -71,7 +71,7 @@ export function initialize() {
 
     /**
      * An optional options object to be used in a11yCheck.
-     * Defaults to `undefined` if not set in the application's configuration.
+     * Defaults to empty object if not set in the application's configuration.
      * @public
      * @type {Object}
      */


### PR DESCRIPTION
Provides empty object if axeOptions are not defined to prevent axe.run from failing. Prior versions of axe worked with undefined options argument, while v3 explicitly expects an object. Resolves the issue by adding empty object default.