### PR TITLE
Adds user timing mechanism for performance profiling

### DIFF
--- a/addon-test-support/audit.js
+++ b/addon-test-support/audit.js
@@ -5,6 +5,7 @@ import RSVP from 'rsvp';
 import config from 'ember-get-config';
 import formatViolation from 'ember-a11y-testing/utils/format-violation';
 import violationsHelper from 'ember-a11y-testing/utils/violations-helper';
+import { mark, markEndAndMeasure } from './utils';
 
 /**
  * Processes the results of calling axe.a11yCheck. If there are any
@@ -53,6 +54,8 @@ function isPlainObj(obj) {
  * @private
  */
 function runA11yAudit(contextSelector = '#ember-testing-container', axeOptions) {
+  mark('a11y_audit_start');
+
   // Support passing axeOptions as a single argument
   if (arguments.length === 1 && isPlainObj(contextSelector)) {
     axeOptions = contextSelector;
@@ -80,7 +83,10 @@ function runA11yAudit(contextSelector = '#ember-testing-container', axeOptions) 
 
   return auditPromise
     .then(a11yAuditCallback)
-    .finally(() => document.body.classList.remove('axe-running'));
+    .finally(() => {
+      document.body.classList.remove('axe-running');
+      markEndAndMeasure('a11y_audit', 'a11y_audit_start', 'a11y_audit_end');
+    });
 }
 
 // Register an async helper to use in acceptance tests

--- a/addon-test-support/utils.js
+++ b/addon-test-support/utils.js
@@ -1,4 +1,80 @@
+/**
+ * Exposes performance API if it exists in the current environment.
+ *
+ * @constant
+ * @private
+ * @type {Booelan}
+ */
+const performance = hasPerformanceApi() ? window.performance : undefined;
+
+/**
+ * Utility to check performance API.
+ *
+ * @return {Boolean}
+ * @private
+ */
+function hasPerformanceApi() {
+  return window &&
+    typeof window.performance !== 'undefined' &&
+    typeof window.performance.mark === 'function' &&
+    typeof window.performance.measure === 'function';
+}
+
+/**
+ * Utility to add a performance marker.
+ *
+ * @param {String} name 
+ * @public
+ */
+export function mark(name) {
+  if (performance) {
+    performance.mark(name);
+  }
+}
+
+/**
+ * Utility to measure performance between the start and end markers.
+ *
+ * @param {String} comment
+ * @param {String} startMark
+ * @param {String} endMark
+ * @return {Void}
+ * @public
+ */
+export function measure(comment, startMark, endMark) {
+  // `performance.measure` may fail if the mark could not be found.
+  // reasons a specific mark could not be found include outside code invoking `performance.clearMarks()`
+  try {
+    performance.measure(comment, startMark, endMark);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('performance.measure could not be executed because of ', e.message);
+  }
+}
+
+/**
+ * Utility to place end marker and measure performance.
+ *
+ * @param {String} comment
+ * @param {String} startMark
+ * @param {String} endMark
+ * @return {Void}
+ * @public
+ */
+export function markEndAndMeasure(comment, startMark, endMark) {
+  if (performance) {
+    mark(endMark);
+    measure(comment, startMark, endMark);
+  }
+}
+
 export default {
+  /**
+   * Utility to get window location object.
+   *
+   * @return {Object}
+   * @public
+   */
   getLocation() {
     return window && window.location;
   }


### PR DESCRIPTION
We'd like to add some simple user timing markers to get a better idea of a11y testing perf impacts on acceptance test suites.