### PR TITLE
Axe-core version bump to 3.2.1

### DIFF
--- a/app/instance-initializers/axe-component.js
+++ b/app/instance-initializers/axe-component.js
@@ -11,6 +11,9 @@ import formatViolation from 'ember-a11y-testing/utils/format-violation';
 import violationsHelper from 'ember-a11y-testing/utils/violations-helper';
 import concurrentAxe from 'ember-a11y-testing/utils/concurrent-axe';
 
+// The following instance initializer augments the base component class to enable component self auditing during (re)render.
+// This visual component audit mechanism is exclusively used during development and does not get invoked when executing tests.
+
 const VIOLATION_CLASS__LEVEL_1 = 'axe-violation--level-1';
 const VIOLATION_CLASS__LEVEL_2 = 'axe-violation--level-2';
 const VIOLATION_CLASS__LEVEL_3 = 'axe-violation--level-3';

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "axe-core": "^3.1.2",
+    "axe-core": "^3.2.2",
     "broccoli-funnel": "^2.0.1",
     "ember-cli-babel": "^6.8.2",
     "ember-cli-version-checker": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,9 +325,9 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
 
-axe-core@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.1.2.tgz#ca0aff897ebefca7552f97859dc1217c06c4f9e6"
+axe-core@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.2.2.tgz#b06d6e9ae4636d706068843272bfaeed3fe97362"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"


### PR DESCRIPTION
Bumping axe-core to latest release, which has improved performance to speed up a11y audits. Also including a comment for visual audit instance initializer based on discussions with @stefanpenner.