### PR TITLE
Fixes #127

### DIFF
--- a/addon-test-support/audit.js
+++ b/addon-test-support/audit.js
@@ -1,6 +1,5 @@
 import { registerAsyncHelper } from '@ember/test';
 import { assert } from '@ember/debug';
-import Ember from 'ember';
 import RSVP from 'rsvp';
 import config from 'ember-get-config';
 import formatViolation from 'ember-a11y-testing/utils/format-violation';
@@ -26,7 +25,7 @@ function a11yAuditCallback(results) {
       let violationMessage = formatViolation(violation, violationNodes);
       allViolations.push(violationMessage);
 
-      Ember.Logger.error(violationMessage, violation);
+      console.error(violationMessage, violation);  // eslint-disable-line no-console
       violationsHelper.push(violation);
     }
 

--- a/addon/instance-initializers/axe-component.js
+++ b/addon/instance-initializers/axe-component.js
@@ -170,14 +170,14 @@ export function initialize(appInstance) {
             nodes = violation.nodes;
 
             if (isEmpty(nodes) || nodes.length === 0) {
-              Ember.Logger.error(formatViolation(violation), violation);
+              console.error(formatViolation(violation), violation); // eslint-disable-line no-console
               violationsHelper.push(violation);
             }
 
             for (let j = 0, k = nodes.length; j < k; j++) {
               nodeData = nodes[j];
 
-              Ember.Logger.error(formatViolation(violation, nodeData.html), violation);
+              console.error(formatViolation(violation, nodeData.html), violation); // eslint-disable-line no-console
               violationsHelper.push(violation);
 
               if (nodeData) {

--- a/addon/utils/violations-helper.js
+++ b/addon/utils/violations-helper.js
@@ -1,5 +1,3 @@
-import Ember from 'ember';
-
 /**
  * @module ember-a11y-testing
  *
@@ -96,8 +94,10 @@ export class ViolationsHelper {
    */
   logTip() {
     if (this.count && !this.hasLoggedTip) {
-      Ember.Logger.info("You can inspect or filter your violations from the console with: window.violationsHelper");
-      Ember.Logger.info("For a description of violationsHelper's API, see: https://github.com/ember-a11y/ember-a11y-testing/blob/master/addon/utils/violations-helper.js");
+      /* eslint-disable no-console */
+      console.info("You can inspect or filter your violations from the console with: window.violationsHelper");
+      console.info("For a description of violationsHelper's API, see: https://github.com/ember-a11y/ember-a11y-testing/blob/master/addon/utils/violations-helper.js");
+      /* eslint-enable no-console */
       this.hasLoggedTip = true;
     }
   }

--- a/tests/integration/instance-initializers/axe-component-test.js
+++ b/tests/integration/instance-initializers/axe-component-test.js
@@ -10,9 +10,6 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import wait from 'ember-test-helpers/wait';
 
-const {
-  Logger
-} = Ember;
 const ID_TEST_DOM_NODE = 'sign-up-button';
 
 const VIOLATION_CLASS__LEVEL_1 = 'axe-violation--level-1';
@@ -92,7 +89,7 @@ moduleForComponent('component:axe-component', 'Integration | Instance Initialize
 
     initialize();
     this.register('component:axe-component', Component.extend());
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   },
 
   afterEach() {
@@ -166,7 +163,7 @@ test('audit should log any violations found', function(assert) {
     }]
   });
 
-  const logSpy = sandbox.spy(Logger, 'error');
+  const logSpy = sandbox.spy(console, 'error');
   this.render(hbs`{{#axe-component}}{{content}}{{/axe-component}}`);
 
   return wait().then(() => {
@@ -187,7 +184,7 @@ test('audit should log any violations found if no nodes are found', function(ass
     }]
   });
 
-  const logSpy = sandbox.spy(Logger, 'error');
+  const logSpy = sandbox.spy(console, 'error');
   this.render(hbs`{{#axe-component}}{{content}}{{/axe-component}}`);
   return wait().then(() => assert.ok(logSpy.calledOnce));
 });
@@ -197,7 +194,7 @@ test('audit should do nothing if no violations found', function(assert) {
 
   stubA11yCheck(sandbox, { violations: [] });
 
-  const logSpy = sandbox.spy(Logger, 'error');
+  const logSpy = sandbox.spy(console, 'error');
   this.render(hbs`{{#axe-component}}{{content}}{{/axe-component}}`);
 
   assert.ok(logSpy.notCalled);

--- a/tests/unit/instance-initializers/violations-helper-test.js
+++ b/tests/unit/instance-initializers/violations-helper-test.js
@@ -1,19 +1,9 @@
-/* global sinon */
 import { initialize } from 'dummy/instance-initializers/violations-helper';
 import { module, test } from 'qunit';
 
 let application;
-let sandbox;
 
-module('Unit | Instance Initializer | violations-helper', {
-  beforeEach() {
-    sandbox = sinon.sandbox.create();
-  },
-
-  afterEach() {
-    sandbox.restore();
-  }
-});
+module('Unit | Instance Initializer | violations-helper');
 
 test('initializer sets a violationsHelper in the global scope', function(assert) {
   initialize(application);

--- a/tests/unit/utils/concurrent-axe-test.js
+++ b/tests/unit/utils/concurrent-axe-test.js
@@ -16,7 +16,7 @@ module('Unit | Utils | ConcurrentAxe', {
   },
   beforeEach() {
     this.subject = new ConcurrentAxe();
-    this.sandbox = sinon.sandbox.create();
+    this.sandbox = sinon.createSandbox();
     this.axeRunStub = this.sandbox.stub(axe, 'run');
     this.testNode = setupDOMNode();
   },
@@ -33,7 +33,7 @@ test('util calls axe.run with the correct arguments', function(assert) {
   this.subject.run(this.testNode, this.testOptions, this.testCallback);
 
   return wait().then(() => {
-    assert.ok(this.axeRunStub.withArgs(this.testNode, this.testOptions, this.testCallback).calledOnce, 'called once with all arguments');
+    assert.ok(this.axeRunStub.calledOnceWith(this.testNode, this.testOptions, this.testCallback), 'called once with all arguments');
   });
 });
 

--- a/tests/unit/utils/violations-helper-test.js
+++ b/tests/unit/utils/violations-helper-test.js
@@ -1,13 +1,12 @@
 /* global sinon */
 import { module, test } from 'qunit';
 import { ViolationsHelper } from 'ember-a11y-testing/utils/violations-helper';
-import Ember from 'ember';
 
 let sandbox;
 
 module('Unit | Utils | ViolationsHelper', {
   beforeEach() {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
   },
 
   afterEach() {
@@ -79,7 +78,7 @@ test('filterBy node', function(assert) {
 
 test('only logs tip if there are violations', function(assert) {
   let violationsHelper = new ViolationsHelper();
-  let loggerInfoSpy = sandbox.spy(Ember.Logger, 'info');
+  let loggerInfoSpy = sandbox.spy(console, 'info');
 
   violationsHelper.logTip();
   assert.ok(!loggerInfoSpy.called, "Nothing is logged if there are no violations");
@@ -92,7 +91,7 @@ test('only logs tip if there are violations', function(assert) {
 
 test('will not log tip more than once', function(assert) {
   let violationsHelper = new ViolationsHelper('violation');
-  let loggerInfoSpy = sandbox.spy(Ember.Logger, 'info');
+  let loggerInfoSpy = sandbox.spy(console, 'info');
 
   violationsHelper.logTip();
   assert.ok(loggerInfoSpy.called);


### PR DESCRIPTION
Removes usage of soon to be deprecated Ember.Logger. Also fixes Sinon.js deprecation warnings by replacing all sinon.sandbox.create() calls. Additionally includes some minor cleanup of a couple tests.

I initially created a utility conditional wrapper around console calls, but found such a thing to be pretty tricky to test reliably. Even though this addon supports Ember 2.x, after giving it some thought, I don't see a good reason why folks would be doing dev work or running tests with something like IE 10, especially given that this is a dev-only addon and does not make it to production code.