### PR TITLE
Fixes #124. Allows a11yAudit to account for axe include/exclude context param.

### DIFF
--- a/addon-test-support/audit.js
+++ b/addon-test-support/audit.js
@@ -45,6 +45,18 @@ function isPlainObj(obj) {
 }
 
 /**
+ * Determines whether supplied object contains `include` and `exclude` axe
+ * context selector properties. This is necessary to distinguish an axe
+ * config object from a context selector object, after a single argument
+ * is supplied to `runA11yAudit`.
+ * @param {Object} obj
+ * @return {Boolean}
+ */
+function isNotSelectorObj(obj) {
+  return !obj.hasOwnProperty('include') && !obj.hasOwnProperty('exclude');
+}
+
+/**
  * Runs the axe a11y audit with the given context selector and options.
  * The context defaults to '#ember-testing-container' if not specified.
  * The options default axe-core defaults.
@@ -56,7 +68,7 @@ function runA11yAudit(contextSelector = '#ember-testing-container', axeOptions) 
   mark('a11y_audit_start');
 
   // Support passing axeOptions as a single argument
-  if (arguments.length === 1 && isPlainObj(contextSelector)) {
+  if (arguments.length === 1 && isPlainObj(contextSelector) && isNotSelectorObj(contextSelector)) {
     axeOptions = contextSelector;
     contextSelector = '#ember-testing-container';
   }

--- a/addon/utils/concurrent-axe.js
+++ b/addon/utils/concurrent-axe.js
@@ -20,7 +20,7 @@ export class ConcurrentAxe {
    * @return {Void}
    */
   run(element, options, callback) {
-    if (this._timer) {
+    if (this._timer !== null) {
       this._queue.push(arguments);
     } else {
       this._timer = next(() => {

--- a/tests/acceptance/a11y-audit-test.js
+++ b/tests/acceptance/a11y-audit-test.js
@@ -71,6 +71,36 @@ test('a11yAudit should properly scope to a specified html element context (not r
   });
 });
 
+test('a11yAudit accounts for axe.run include and exclude context parameter', function(assert) {
+  const exclSelectors = [
+    [SELECTORS.failingComponent],
+    ['[data-test-selector="labeless-text-input"]'],
+    ['[data-test-selector="poor-text-contrast"]'],
+    ['[data-test-selector="paragraph-with-blink-tag"]'],
+    ['[data-test-selector="ungrouped-radio-inputs"]'],
+    ['[data-test-selector="noise-level-selection"]']
+  ];
+
+  visit('/');
+
+  a11yAudit({
+    include: [[SELECTORS.passingComponent]]
+  });
+
+  a11yAudit({
+    exclude: exclSelectors
+  });
+
+  a11yAudit({
+    include: [['#ember-testing-container']],
+    exclude: exclSelectors
+  });
+
+  andThen(() => {
+    assert.ok(true, 'no errors should have been found in a11yAudit');
+  });
+});
+
 test('a11yAudit can accept an options hash in addition to context', function(assert) {
   visit('/');
 

--- a/tests/acceptance/a11y-audit-test.js
+++ b/tests/acceptance/a11y-audit-test.js
@@ -72,15 +72,6 @@ test('a11yAudit should properly scope to a specified html element context (not r
 });
 
 test('a11yAudit accounts for axe.run include and exclude context parameter', function(assert) {
-  const exclSelectors = [
-    [SELECTORS.failingComponent],
-    ['[data-test-selector="labeless-text-input"]'],
-    ['[data-test-selector="poor-text-contrast"]'],
-    ['[data-test-selector="paragraph-with-blink-tag"]'],
-    ['[data-test-selector="ungrouped-radio-inputs"]'],
-    ['[data-test-selector="noise-level-selection"]']
-  ];
-
   visit('/');
 
   a11yAudit({
@@ -88,12 +79,15 @@ test('a11yAudit accounts for axe.run include and exclude context parameter', fun
   });
 
   a11yAudit({
-    exclude: exclSelectors
-  });
-
-  a11yAudit({
     include: [['#ember-testing-container']],
-    exclude: exclSelectors
+    exclude: [
+      [SELECTORS.failingComponent],
+      ['[data-test-selector="labeless-text-input"]'],
+      ['[data-test-selector="paragraph-with-blink-tag"]'],
+      ['[data-test-selector="ungrouped-radio-inputs"]'],
+      ['[data-test-selector="noise-level-selection"]'],
+      ['[data-test-selector="poor-text-contrast"]']
+    ]
   });
 
   andThen(() => {

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,7 +1,7 @@
 <div class="application o-content-box">
 
   <header class="application__header">
-    <h2 class="u-align-center">Ember A11y Testing</h2>
+    <h1 class="u-align-center">Ember A11y Testing</h1>
   </header>
 
   <main class="application__main-content u-relative u-fill-width o-content-box--lg">

--- a/tests/dummy/app/templates/components/violations-grid-item.hbs
+++ b/tests/dummy/app/templates/components/violations-grid-item.hbs
@@ -1,5 +1,5 @@
 <section class="c-violations-grid-item__header">
-  <h4 class="c-violations-grid-item__title u-align-center">{{title}}</h4>
+  <h3 class="c-violations-grid-item__title u-align-center">{{title}}</h3>
 </section>
 
 <section class="c-violations-grid-item__body u-relative">

--- a/tests/dummy/app/templates/violations.hbs
+++ b/tests/dummy/app/templates/violations.hbs
@@ -3,7 +3,7 @@
   <span class="p-violations__header-hint">&#42;Open your developer console to view violation logging</span>
 </header>
 
-<section class="p-violations__noise-selectors">
+<section class="p-violations__noise-selectors" data-test-selector="noise-level-selection">
 
   <fieldset class="c-radio-track u-align-center u-relative">
     <legend class="c-radio-track__heading">Visual Noise Level</legend>
@@ -93,7 +93,7 @@
     {{#violations-grid-item class="p-violations__grid-item" title="Poorly Contrasting Text Color" turnAuditOff=true}}
       {{#x-paragraph
         class="p-violations__grid-item-content--low-contrast-text"
-        data-test-selector="labeless-text-input"
+        data-test-selector="poor-text-contrast"
         id="violations__low-contrast-text"
         visualNoiseLevel=model.currentNoiseLevel}}
           Swoooosh
@@ -119,7 +119,7 @@
         💡 PRO TIP: In lieu of a <radiogroup>, a containing <fieldset>
         here would make these accessible.
       --}}
-      <div class="p-violations__grid-item-content--radio-items">
+      <div class="p-violations__grid-item-content--radio-items" data-test-selector="ungrouped-radio-inputs">
         <label class="u-fill-width u-align-center p-violations__grid-item-content--radio" for="violations__radio-group-items--strawberries">
           Strawberries
           {{radio-button-input name="fruits" groupValue=model.currentFruit value="Strawberries" id="violations__radio-group-items--strawberries" visualNoiseLevel=model.currentNoiseLevel}}

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
Adds fix by checking for include and/or exclude properties. Adds test to verify correct behavior.