### PR TITLE
Fixes code included in production builds [#108]

### DIFF
--- a/addon/instance-initializers/axe-component.js
+++ b/addon/instance-initializers/axe-component.js
@@ -46,7 +46,7 @@ export function initialize(appInstance) {
 
   const {
     turnAuditOff: configuredTurnAuditOff,
-    excludeAxeCore,
+    excludeAxeCore = false,
     axeOptions = {},
     axeCallback,
     visualNoiseLevel: configuredVisualNoiseLevel,
@@ -59,7 +59,10 @@ export function initialize(appInstance) {
 
   // Avoid modifying the Component class if the visual audit feature is configured disabled
   // and axe-core is excluded from the dev build
-  if (turnAuditOff && excludeAxeCore) { return; }
+  if ((turnAuditOff && excludeAxeCore) || typeof axe === 'undefined') {
+    hasRan = true;
+    return;
+  }
 
   Component.reopen({
     /**

--- a/index.js
+++ b/index.js
@@ -59,11 +59,34 @@ module.exports = {
   treeForApp: function(tree) {
     var checker = new VersionChecker(this);
     var isProductionBuild = process.env.EMBER_ENV === 'production';
-    var isOldEmber = checker.for('ember', 'bower').lt('1.13.0');
+    var isOldEmber = checker.forEmber().lt('1.13.0');
 
     if (isProductionBuild || isOldEmber) {
       tree = new Funnel(tree, {
-        exclude: [/instance-initializers\/axe-component|violations-helper.js/]
+        exclude: [/instance-initializers\/(axe-component|violations-helper)\.js/]
+      });
+    }
+
+    return tree;
+  },
+
+  /**
+   * Exclude all addon code during build if this is a
+   * production build or if the version of Ember being used is less than 1.13.
+   * @override
+   */
+  treeForAddon: function() {
+    var tree = this._super.treeForAddon.apply(this, arguments);
+    var checker = new VersionChecker(this);
+    var isProductionBuild = process.env.EMBER_ENV === 'production';
+    var isOldEmber = checker.forEmber().lt('1.13.0');
+
+    if (isProductionBuild || isOldEmber) {
+      tree = new Funnel(tree, {
+        exclude: [
+          /instance-initializers\/(axe-component|violations-helper)\.js/,
+          /utils\/(concurrent-axe|format-violation|is-background-replaced-element|violations-helper)\.js/
+        ]
       });
     }
 


### PR DESCRIPTION
Adds override to exclude all addon related code from production builds.

Makes axe check a bit more defensive.

- We recently ran into an issue where the axe-component initializer was getting bundled with a bunch of engines, causing exceptions by calling axe where it didn't exist. Although this was ultimately a build issue not related to the addon, the failure can definitely be made much more graceful.