### PR TITLE
Fix build issues due to Node.js v8 EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "8"
+  - "10"
 
-sudo: required
+os: linux
+
 dist: trusty
 
 addons:
@@ -18,7 +19,7 @@ env:
   global:
     # See https://git.io/vdao3 for details.
     - JOBS=1
-  matrix:
+  jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - EMBER_TRY_SCENARIO=ember-lts-2.18
@@ -29,7 +30,7 @@ env:
     - EMBER_TRY_SCENARIO=ember-canary
     - EMBER_TRY_SCENARIO=ember-default
 
-matrix:
+jobs:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "sass": "1.17.3"
   },
   "engines": {
-    "node": "8.* || 10.* || >= 12"
+    "node": "10.* || >= 12"
   },
   "ember-addon": {
     "demoURL": "http://ember-a11y.github.io/ember-a11y-testing",


### PR DESCRIPTION
The Travis CI build is currently broken due to a transient dependency that no longer supports Node v8. I'm bumping minimum support to v10 as v8 became EOL in January. This also matches the current support level for Ember CLI. Also fixed Travis config validation warnings.