### PR TITLE
Converts the `Ember.assert` usage to throwing error for failing tests

### DIFF
--- a/addon-test-support/audit.ts
+++ b/addon-test-support/audit.ts
@@ -39,7 +39,7 @@ function processAxeResults(results: AxeResults) {
   if (violations.length) {
     let allViolations = [];
 
-    for (let i = 0, l = violations.length; i < l; i++) {
+    for (let i = 0; i < violations.length; i++) {
       let violation = violations[i];
       let violationNodes = violation.nodes.map((node) => node.html);
 
@@ -51,7 +51,7 @@ function processAxeResults(results: AxeResults) {
     }
 
     let allViolationMessages = allViolations.join('\n');
-    assert(
+    throw new Error(
       `The page should have no accessibility violations. Violations:\n${allViolationMessages}`
     );
   }

--- a/addon-test-support/audit.ts
+++ b/addon-test-support/audit.ts
@@ -1,4 +1,3 @@
-import { assert } from '@ember/debug';
 import RSVP from 'rsvp';
 import {
   run,

--- a/tests/acceptance/a11y-audit-test.js
+++ b/tests/acceptance/a11y-audit-test.js
@@ -16,15 +16,11 @@ module('Acceptance | a11y audit', function (hooks) {
 
     await visit('/');
 
-    try {
-      await a11yAudit();
-      assert.ok(false, 'a11yAudit should have thrown an error on violations');
-    } catch (error) {
-      let foundExpectedError = error.message.startsWith(
-        'The page should have no accessibility violations. Violations:'
-      );
-      assert.ok(foundExpectedError, 'error message is correct');
-    }
+    await assert.rejects(
+      a11yAudit(),
+      /The page should have no accessibility violations. Violations:/,
+      'error message is correct'
+    );
   });
 
   test('a11yAudit should properly scope to a specified string context selector', async function (assert) {
@@ -32,22 +28,14 @@ module('Acceptance | a11y audit', function (hooks) {
 
     await visit('/');
 
-    try {
-      await a11yAudit(SELECTORS.passingComponent);
-      assert.ok(true, 'a11yAudit should not have discovered any issues');
-    } catch (error) {
-      assert.ok(false, error.message);
-    }
+    await a11yAudit(SELECTORS.passingComponent);
+    assert.ok(true, 'a11yAudit should not have discovered any issues');
 
-    try {
-      await a11yAudit(SELECTORS.failingComponent);
-      assert.ok(false, 'a11yAudit should have thrown an error on violations');
-    } catch (error) {
-      let foundExpectedError = error.message.startsWith(
-        'The page should have no accessibility violations. Violations:'
-      );
-      assert.ok(foundExpectedError, 'error message is correct');
-    }
+    await assert.rejects(
+      a11yAudit(SELECTORS.failingComponent),
+      /The page should have no accessibility violations. Violations:/,
+      'error message is correct'
+    );
   });
 
   test('a11yAudit should properly scope to a specified jquery context (not recommended)', async function (assert) {

--- a/tests/acceptance/a11y-audit-test.js
+++ b/tests/acceptance/a11y-audit-test.js
@@ -21,7 +21,7 @@ module('Acceptance | a11y audit', function (hooks) {
       assert.ok(false, 'a11yAudit should have thrown an error on violations');
     } catch (error) {
       let foundExpectedError = error.message.startsWith(
-        'Assertion Failed: The page should have no accessibility violations. Violations:'
+        'The page should have no accessibility violations. Violations:'
       );
       assert.ok(foundExpectedError, 'error message is correct');
     }
@@ -44,7 +44,7 @@ module('Acceptance | a11y audit', function (hooks) {
       assert.ok(false, 'a11yAudit should have thrown an error on violations');
     } catch (error) {
       let foundExpectedError = error.message.startsWith(
-        'Assertion Failed: The page should have no accessibility violations. Violations:'
+        'The page should have no accessibility violations. Violations:'
       );
       assert.ok(foundExpectedError, 'error message is correct');
     }

--- a/tests/integration/helpers/a11y-audit-if-test.js
+++ b/tests/integration/helpers/a11y-audit-if-test.js
@@ -31,7 +31,7 @@ module('Integration | Helper | a11yAuditIf', function (hooks) {
       assert.ok(false, 'audit should have failed');
     } catch (error) {
       let foundExpectedError = error.message.startsWith(
-        'Assertion Failed: The page should have no accessibility violations.'
+        'The page should have no accessibility violations.'
       );
       assert.ok(foundExpectedError);
     }

--- a/tests/integration/helpers/a11y-audit-test.js
+++ b/tests/integration/helpers/a11y-audit-test.js
@@ -21,7 +21,7 @@ module('Integration | Helper | a11yAudit', function (hooks) {
       assert.ok(false, 'should have failed');
     } catch (error) {
       let found = error.message.startsWith(
-        'Assertion Failed: The page should have no accessibility violations. Violations:'
+        'The page should have no accessibility violations. Violations:'
       );
       assert.ok(found, 'error message is correct');
     }

--- a/tests/integration/helpers/a11y-audit-test.js
+++ b/tests/integration/helpers/a11y-audit-test.js
@@ -16,15 +16,11 @@ module('Integration | Helper | a11yAudit', function (hooks) {
   test('a11yAudit catches violations successfully', async function (assert) {
     await render(hbs`{{#axe-component}}<button></button>{{/axe-component}}`);
 
-    try {
-      await a11yAudit(this.element);
-      assert.ok(false, 'should have failed');
-    } catch (error) {
-      let found = error.message.startsWith(
-        'The page should have no accessibility violations. Violations:'
-      );
-      assert.ok(found, 'error message is correct');
-    }
+    await assert.rejects(
+      a11yAudit(this.element),
+      /The page should have no accessibility violations. Violations:/,
+      'error message is correct'
+    );
   });
 
   test('a11yAudit can use custom axe options', async function (assert) {


### PR DESCRIPTION
This addon was leveraging Ember's `assert` function to trigger failures. This PR removes that in favor of plain `Error` objects (which is ultimately what `assert` uses under the hood.