### PR TITLE
Converting utils to TS to fix compile time errors

### DIFF
--- a/addon/utils/format-violation.ts
+++ b/addon/utils/format-violation.ts
@@ -1,4 +1,4 @@
-import { Result } from 'axe-core';
+import type { Result } from 'axe-core';
 
 /**
  * Formats the axe violation for human consumption

--- a/addon/utils/format-violation.ts
+++ b/addon/utils/format-violation.ts
@@ -1,10 +1,15 @@
+import { Result } from 'axe-core';
+
 /**
  * Formats the axe violation for human consumption
  *
  * @param {AxeViolation} violation
  * @param {string | string[]} markup (optional) string of HTML relevant to the violation
  */
-export default function formatViolation(violation, markup) {
+export default function formatViolation(
+  violation: Result,
+  markup: string | string[]
+) {
   if (!violation) {
     throw new Error(
       'formatViolation called without required parameter: violation'

--- a/addon/utils/violations-helper.ts
+++ b/addon/utils/violations-helper.ts
@@ -1,3 +1,5 @@
+import { Result } from 'axe-core';
+
 /**
  * @module ember-a11y-testing
  *
@@ -18,6 +20,8 @@
  * @class ViolationsHelper
  */
 export class ViolationsHelper {
+  violations: Result[];
+  hasLoggedTip: boolean;
   /**
    * Instantiate by calling either:
    *
@@ -66,7 +70,7 @@ export class ViolationsHelper {
    * @public
    * @return {Void}
    */
-  push(violation) {
+  push(violation: Result) {
     this.violations.push(violation);
   }
 
@@ -81,13 +85,13 @@ export class ViolationsHelper {
    * @public
    * @return {Array}
    */
-  filterBy(key, value) {
-    if (key === 'rule') {
+  filterBy(key: keyof Result, value: any) {
+    if (<any>key === 'rule') {
       key = 'id';
     }
 
     return this.violations.filter((violation) => {
-      if (key === 'node') {
+      if (<any>key === 'node') {
         return violation.nodes[0].target[0] === value;
       }
       return violation[key] === value;

--- a/addon/utils/violations-helper.ts
+++ b/addon/utils/violations-helper.ts
@@ -1,4 +1,4 @@
-import { Result } from 'axe-core';
+import type { Result } from 'axe-core';
 
 /**
  * @module ember-a11y-testing


### PR DESCRIPTION
Converts

- addon/utils/format-violation.js
- addon/utils/violations-helper.js

to TS to avoid issue with compile-time errors due to JS imported into TS.