### PR TITLE
Adds custom reporter capability

### DIFF
--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -8,4 +8,4 @@ export {
 } from './setup-global-a11y-hooks';
 export { setCustomReporter } from './reporter';
 
-export { InvocationStrategy } from './types';
+export { InvocationStrategy, A11yAuditReporter } from './types';

--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -6,5 +6,6 @@ export {
   setupGlobalA11yHooks,
   teardownGlobalA11yHooks,
 } from './setup-global-a11y-hooks';
+export { setCustomReporter } from './reporter';
 
 export { InvocationStrategy } from './types';

--- a/addon-test-support/reporter.ts
+++ b/addon-test-support/reporter.ts
@@ -16,7 +16,7 @@ const DEFAULT_REPORTER = async (results: AxeResults) => {
     let allViolationMessages = allViolations.join('\n');
     throw new Error(
       `The page should have no accessibility violations. Violations:\n${allViolationMessages}
-To rerun this specific failure, use the following query params: &${QUnit.config.current.testId}&enableA11yAudit=true`
+To rerun this specific failure, use the following query params: &testId=${QUnit.config.current.testId}&enableA11yAudit=true`
     );
   }
 };

--- a/addon-test-support/reporter.ts
+++ b/addon-test-support/reporter.ts
@@ -1,10 +1,7 @@
 import QUnit from 'qunit';
 import { AxeResults } from 'axe-core';
 import formatViolation from './format-violation';
-
-interface A11yAuditReporter {
-  (axeResults: AxeResults): Promise<void>;
-}
+import { A11yAuditReporter } from './types';
 
 const DEFAULT_REPORTER = async (results: AxeResults) => {
   let violations = results.violations;

--- a/addon-test-support/reporter.ts
+++ b/addon-test-support/reporter.ts
@@ -1,0 +1,40 @@
+import QUnit from 'qunit';
+import { AxeResults } from 'axe-core';
+import formatViolation from './format-violation';
+
+interface A11yAuditReporter {
+  (axeResults: AxeResults): Promise<void>;
+}
+
+const DEFAULT_REPORTER = async (results: AxeResults) => {
+  let violations = results.violations;
+
+  if (violations.length) {
+    let allViolations = violations.map((violation) => {
+      let violationNodes = violation.nodes.map((node) => node.html);
+
+      return formatViolation(violation, violationNodes);
+    });
+
+    let allViolationMessages = allViolations.join('\n');
+    throw new Error(
+      `The page should have no accessibility violations. Violations:\n${allViolationMessages}
+To rerun this specific failure, use the following query params: &${QUnit.config.current.testId}&enableA11yAudit=true`
+    );
+  }
+};
+
+export let reportA11yAudit: A11yAuditReporter = DEFAULT_REPORTER;
+
+/**
+ * Sets a custom reporter, allowing implementers more specific control over how the results of the
+ * `a11yAudit` calls are processed. Calling this function with no parameters will reset the reporter
+ * to the default reporter.
+ *
+ * @param customReporter {A11yAuditReporter} The reporter to use in a11yAudit
+ */
+export function setCustomReporter(
+  customReporter: A11yAuditReporter = DEFAULT_REPORTER
+) {
+  reportA11yAudit = customReporter;
+}

--- a/addon-test-support/types/index.ts
+++ b/addon-test-support/types/index.ts
@@ -1,3 +1,9 @@
+import { AxeResults } from 'axe-core';
+
 export interface InvocationStrategy {
   (helperName: string, label: string): boolean;
+}
+
+export interface A11yAuditReporter {
+  (axeResults: AxeResults): Promise<void>;
 }

--- a/tests/acceptance/reporter-test.ts
+++ b/tests/acceptance/reporter-test.ts
@@ -1,0 +1,23 @@
+import { AxeResults } from 'axe-core';
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { a11yAudit, setCustomReporter } from 'ember-a11y-testing/test-support';
+
+module('reporter', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('setCustomReporter can correctly set a custom reporter in favor of default', async function (assert) {
+    assert.expect(1);
+
+    setCustomReporter(async (axeResult: AxeResults) => {
+      assert.equal(axeResult.violations.length, 3);
+    });
+
+    await visit('/');
+
+    await a11yAudit();
+
+    setCustomReporter();
+  });
+});

--- a/tests/acceptance/reporter-test.ts
+++ b/tests/acceptance/reporter-test.ts
@@ -7,10 +7,10 @@ import { a11yAudit, setCustomReporter } from 'ember-a11y-testing/test-support';
 module('reporter', function (hooks) {
   setupApplicationTest(hooks);
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     setCustomReporter(); // reset to default value
   });
-  
+
   test('setCustomReporter can correctly set a custom reporter in favor of default', async function (assert) {
     assert.expect(1);
 

--- a/tests/acceptance/reporter-test.ts
+++ b/tests/acceptance/reporter-test.ts
@@ -7,6 +7,10 @@ import { a11yAudit, setCustomReporter } from 'ember-a11y-testing/test-support';
 module('reporter', function (hooks) {
   setupApplicationTest(hooks);
 
+  hooks.afterEach(function() {
+    setCustomReporter(); // reset to default value
+  });
+  
   test('setCustomReporter can correctly set a custom reporter in favor of default', async function (assert) {
     assert.expect(1);
 
@@ -17,7 +21,5 @@ module('reporter', function (hooks) {
     await visit('/');
 
     await a11yAudit();
-
-    setCustomReporter();
   });
 });


### PR DESCRIPTION
As part of #207, this PR adds a new reporter system that will allow us to provide custom reporting for accessibility violations for test runs.

The reporter conforms to the following interface:

```ts
interface A11yAuditReporter {
  (axeResults: AxeResults): Promise<void>;
}
```

A `setCustomReporter` is provided, allowing you to provide a custom `A11yAuditReporter` implementation.

```ts
export function setCustomReporter(
  customReporter: A11yAuditReporter = DEFAULT_REPORTER
): void;
```

This API provides the flexibility to shape the violations in any format you want.