### PR TITLE
Adding ability to post violations via middleware

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,8 @@ module.exports = {
         '.template-lintrc.js',
         'ember-cli-build.js',
         'index.js',
+        'setup-middleware.js',
+        'node-tests/setup-middleware-test.js',
         'testem.js',
         'blueprints/*/index.js',
         'config/**/*.js',

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,6 +25,8 @@ jobs:
         run: yarn lint
       - name: test
         run: yarn test:ember
+      - name: test node
+        run: yarn test:node
 
   floating-dependencies:
     name: Floating dependencies

--- a/.npmignore
+++ b/.npmignore
@@ -23,6 +23,7 @@
 /ember-cli-build.js
 /testem.js
 /tests/
+/node-tests/
 /yarn.lock
 .gitkeep
 

--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -7,5 +7,10 @@ export {
   teardownGlobalA11yHooks,
 } from './setup-global-a11y-hooks';
 export { setCustomReporter } from './reporter';
+export {
+  TEST_SUITE_RESULTS as _TEST_SUITE_RESULTS,
+  middlewareReporter as _middlewareReporter,
+  setupMiddlewareReporter,
+} from './setup-middleware-reporter';
 
 export { InvocationStrategy, A11yAuditReporter } from './types';

--- a/addon-test-support/setup-middleware-reporter.ts
+++ b/addon-test-support/setup-middleware-reporter.ts
@@ -1,0 +1,48 @@
+import QUnit from 'qunit';
+import { getContext, getTestMetadata } from '@ember/test-helpers';
+import { AxeResults } from 'axe-core';
+import { setCustomReporter } from './reporter';
+import { DEBUG } from '@glimmer/env';
+
+export const TEST_SUITE_RESULTS: {
+  moduleName: string;
+  testName: string;
+  helperName: string;
+  stack: string;
+  axeResults: AxeResults;
+}[] = [];
+
+export function buildResult(axeResults: AxeResults) {
+  let { module, testName } = QUnit.config.current;
+  let testMetaData = getTestMetadata(getContext());
+
+  let stack = (!DEBUG && new Error().stack) || '';
+
+  return {
+    moduleName: module.name,
+    testName,
+    helperName: testMetaData.usedHelpers.pop() || '',
+    stack,
+    axeResults,
+  };
+}
+
+export async function middlewareReporter(axeResults: AxeResults) {
+  TEST_SUITE_RESULTS.push(buildResult(axeResults));
+}
+
+export function setupMiddlewareReporter() {
+  setCustomReporter(middlewareReporter);
+
+  QUnit.done(async function () {
+    let response = await fetch('/report-violations', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(TEST_SUITE_RESULTS),
+    });
+
+    return response.json();
+  });
+}

--- a/addon-test-support/setup-middleware-reporter.ts
+++ b/addon-test-support/setup-middleware-reporter.ts
@@ -4,13 +4,15 @@ import { AxeResults } from 'axe-core';
 import { setCustomReporter } from './reporter';
 import { DEBUG } from '@glimmer/env';
 
-export const TEST_SUITE_RESULTS: {
+interface AxeTestResult {
   moduleName: string;
   testName: string;
   helperName: string;
   stack: string;
   axeResults: AxeResults;
-}[] = [];
+}
+
+export const TEST_SUITE_RESULTS: AxeTestResult[] = [];
 
 export function buildResult(axeResults: AxeResults) {
   let { module, testName } = QUnit.config.current;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const Funnel = require('broccoli-funnel');
 const MergeTrees = require('broccoli-merge-trees');
 const VersionChecker = require('ember-cli-version-checker');
+const setupMiddleware = require('./setup-middleware');
 
 // The different types/area for which we have content for.
 const ALLOWED_CONTENT_FOR = ['head-footer', 'test-head-footer'];
@@ -60,5 +61,17 @@ module.exports = {
         path.join(__dirname, 'content-for', type + '.html')
       );
     }
+  },
+
+  serverMiddleware(startOptions) {
+    setupMiddleware(startOptions.app, {
+      root: this.project.root,
+    });
+  },
+
+  testemMiddleware(app) {
+    setupMiddleware(app, {
+      root: this.project.root,
+    });
   },
 };

--- a/node-tests/fixtures/violations.json
+++ b/node-tests/fixtures/violations.json
@@ -1,0 +1,3325 @@
+{
+  "testEngine": {
+    "name": "axe-core",
+    "version": "4.0.1"
+  },
+  "testRunner": {
+    "name": "axe"
+  },
+  "testEnvironment": {
+    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36",
+    "windowWidth": 1390,
+    "windowHeight": 1089,
+    "orientationAngle": 0,
+    "orientationType": "landscape-primary"
+  },
+  "timestamp": "2020-09-04T18:11:29.913Z",
+  "url": "http://localhost:4200/tests/index.html?testId=40d80690&enableA11yAudit=",
+  "toolOptions": {
+    "reporter": "v1"
+  },
+  "violations": [
+    {
+      "id": "button-name",
+      "impact": "critical",
+      "tags": [
+        "cat.name-role-value",
+        "wcag2a",
+        "wcag412",
+        "section508",
+        "section508.22.a"
+      ],
+      "description": "Ensures buttons have discernible text",
+      "help": "Buttons must have discernible text",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/button-name?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "button-has-visible-text",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Element does not have inner text that is visible to screen readers"
+            },
+            {
+              "id": "aria-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "aria-label attribute does not exist or is empty"
+            },
+            {
+              "id": "aria-labelledby",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty"
+            },
+            {
+              "id": "role-presentation",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element's default semantics were not overridden with role=\"presentation\""
+            },
+            {
+              "id": "role-none",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element's default semantics were not overridden with role=\"none\""
+            },
+            {
+              "id": "non-empty-title",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Element has no title attribute or the title attribute is empty"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": "critical",
+          "html": "<button data-test-selector=\"empty-button\" id=\"violations__empty-button\" class=\"c-button ember-view\">\n</button>",
+          "target": [
+            "#violations__empty-button"
+          ],
+          "failureSummary": "Fix any of the following:\n  Element does not have inner text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"\n  Element has no title attribute or the title attribute is empty"
+        }
+      ]
+    },
+    {
+      "id": "image-alt",
+      "impact": "critical",
+      "tags": [
+        "cat.text-alternatives",
+        "wcag2a",
+        "wcag111",
+        "section508",
+        "section508.22.a"
+      ],
+      "description": "Ensures <img> elements have alternate text or a role of none or presentation",
+      "help": "Images must have alternate text",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/image-alt?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "has-alt",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Element does not have an alt attribute"
+            },
+            {
+              "id": "aria-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "aria-label attribute does not exist or is empty"
+            },
+            {
+              "id": "aria-labelledby",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty"
+            },
+            {
+              "id": "non-empty-title",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Element has no title attribute or the title attribute is empty"
+            },
+            {
+              "id": "role-presentation",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element's default semantics were not overridden with role=\"presentation\""
+            },
+            {
+              "id": "role-none",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element's default semantics were not overridden with role=\"none\""
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": "critical",
+          "html": "<img src=\"assets/img/empire-state-building-moonlight.png\" id=\"violations__img-without-alt\" class=\"u-fill c-img ember-view\">",
+          "target": [
+            "#violations__img-without-alt"
+          ],
+          "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\""
+        }
+      ]
+    },
+    {
+      "id": "label",
+      "impact": "critical",
+      "tags": [
+        "cat.forms",
+        "wcag2a",
+        "wcag412",
+        "wcag131",
+        "section508",
+        "section508.22.n"
+      ],
+      "description": "Ensures every form element has a label",
+      "help": "Form elements must have labels",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/label?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "aria-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "aria-label attribute does not exist or is empty"
+            },
+            {
+              "id": "aria-labelledby",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty"
+            },
+            {
+              "id": "implicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element does not have an implicit (wrapped) <label>"
+            },
+            {
+              "id": "explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element does not have an explicit <label>"
+            },
+            {
+              "id": "non-empty-title",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Element has no title attribute or the title attribute is empty"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": "critical",
+          "html": "<input class=\"c-text-input__input\" id=\"violations__labeless-input\" type=\"text\">",
+          "target": [
+            "#violations__labeless-input"
+          ],
+          "failureSummary": "Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Form element does not have an implicit (wrapped) <label>\n  Form element does not have an explicit <label>\n  Element has no title attribute or the title attribute is empty"
+        }
+      ]
+    }
+  ],
+  "passes": [
+    {
+      "id": "aria-allowed-attr",
+      "impact": null,
+      "tags": [
+        "cat.aria",
+        "wcag2a",
+        "wcag412"
+      ],
+      "description": "Ensures ARIA attributes are allowed for an element's role",
+      "help": "Elements must only use allowed ARIA attributes",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-allowed-attr?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "aria-allowed-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attributes are used correctly for the defined role"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "aria-unsupported-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute is supported"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+          "target": [
+            "#noise-level-0"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "aria-allowed-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attributes are used correctly for the defined role"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "aria-unsupported-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute is supported"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+          "target": [
+            "#noise-level-1"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "aria-allowed-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attributes are used correctly for the defined role"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "aria-unsupported-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute is supported"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+          "target": [
+            "#noise-level-2"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "aria-allowed-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attributes are used correctly for the defined role"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "aria-unsupported-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute is supported"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+          "target": [
+            "#noise-level-3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "aria-allowed-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attributes are used correctly for the defined role"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "aria-unsupported-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute is supported"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+          "target": [
+            "#violations__radio-group-items--strawberries"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "aria-allowed-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attributes are used correctly for the defined role"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "aria-unsupported-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute is supported"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+          "target": [
+            "#violations__radio-group-items--blueberries"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "aria-allowed-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attributes are used correctly for the defined role"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "aria-unsupported-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute is supported"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+          "target": [
+            "#violations__radio-group-items--raspberries"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "aria-valid-attr-value",
+      "impact": null,
+      "tags": [
+        "cat.aria",
+        "wcag2a",
+        "wcag412"
+      ],
+      "description": "Ensures all ARIA attributes have valid values",
+      "help": "ARIA attributes must conform to valid values",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-valid-attr-value?application=axeAPI",
+      "nodes": [
+        {
+          "any": [],
+          "all": [
+            {
+              "id": "aria-valid-attr-value",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute values are valid"
+            },
+            {
+              "id": "aria-errormessage",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Uses a supported aria-errormessage technique"
+            }
+          ],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+          "target": [
+            "#noise-level-0"
+          ]
+        },
+        {
+          "any": [],
+          "all": [
+            {
+              "id": "aria-valid-attr-value",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute values are valid"
+            },
+            {
+              "id": "aria-errormessage",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Uses a supported aria-errormessage technique"
+            }
+          ],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+          "target": [
+            "#noise-level-1"
+          ]
+        },
+        {
+          "any": [],
+          "all": [
+            {
+              "id": "aria-valid-attr-value",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute values are valid"
+            },
+            {
+              "id": "aria-errormessage",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Uses a supported aria-errormessage technique"
+            }
+          ],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+          "target": [
+            "#noise-level-2"
+          ]
+        },
+        {
+          "any": [],
+          "all": [
+            {
+              "id": "aria-valid-attr-value",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute values are valid"
+            },
+            {
+              "id": "aria-errormessage",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Uses a supported aria-errormessage technique"
+            }
+          ],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+          "target": [
+            "#noise-level-3"
+          ]
+        },
+        {
+          "any": [],
+          "all": [
+            {
+              "id": "aria-valid-attr-value",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute values are valid"
+            },
+            {
+              "id": "aria-errormessage",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Uses a supported aria-errormessage technique"
+            }
+          ],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+          "target": [
+            "#violations__radio-group-items--strawberries"
+          ]
+        },
+        {
+          "any": [],
+          "all": [
+            {
+              "id": "aria-valid-attr-value",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute values are valid"
+            },
+            {
+              "id": "aria-errormessage",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Uses a supported aria-errormessage technique"
+            }
+          ],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+          "target": [
+            "#violations__radio-group-items--blueberries"
+          ]
+        },
+        {
+          "any": [],
+          "all": [
+            {
+              "id": "aria-valid-attr-value",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute values are valid"
+            },
+            {
+              "id": "aria-errormessage",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Uses a supported aria-errormessage technique"
+            }
+          ],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+          "target": [
+            "#violations__radio-group-items--raspberries"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "aria-valid-attr",
+      "impact": null,
+      "tags": [
+        "cat.aria",
+        "wcag2a",
+        "wcag412"
+      ],
+      "description": "Ensures attributes that begin with aria- are valid ARIA attributes",
+      "help": "ARIA attributes must conform to valid names",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-valid-attr?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "aria-valid-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute name is valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+          "target": [
+            "#noise-level-0"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "aria-valid-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute name is valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+          "target": [
+            "#noise-level-1"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "aria-valid-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute name is valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+          "target": [
+            "#noise-level-2"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "aria-valid-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute name is valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+          "target": [
+            "#noise-level-3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "aria-valid-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute name is valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+          "target": [
+            "#violations__radio-group-items--strawberries"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "aria-valid-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute name is valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+          "target": [
+            "#violations__radio-group-items--blueberries"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "aria-valid-attr",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "ARIA attribute name is valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+          "target": [
+            "#violations__radio-group-items--raspberries"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "avoid-inline-spacing",
+      "impact": null,
+      "tags": [
+        "wcag21aa",
+        "wcag1412"
+      ],
+      "description": "Ensure that text spacing set through style attributes can be adjusted with custom stylesheets",
+      "help": "Inline text spacing must be adjustable with custom stylesheets",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/avoid-inline-spacing?application=axeAPI",
+      "nodes": [
+        {
+          "any": [],
+          "all": [
+            {
+              "id": "avoid-inline-spacing",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "No inline styles with '!important' that affect text spacing has been specified"
+            }
+          ],
+          "none": [],
+          "impact": null,
+          "html": "<div id=\"ember-testing-container\" style=\"visibility: visible; position: relative;\">",
+          "target": [
+            "#ember-testing-container"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "blink",
+      "impact": null,
+      "tags": [
+        "cat.time-and-media",
+        "wcag2a",
+        "wcag222",
+        "section508",
+        "section508.22.j"
+      ],
+      "description": "Ensures <blink> elements are not used",
+      "help": "<blink> elements are deprecated and must not be used",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/blink?application=axeAPI",
+      "nodes": [
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "is-on-screen",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Element is not visible"
+            }
+          ],
+          "impact": null,
+          "html": "<blink>like this one!</blink>",
+          "target": [
+            "blink"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "color-contrast",
+      "impact": null,
+      "tags": [
+        "cat.color",
+        "wcag2aa",
+        "wcag143"
+      ],
+      "description": "Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds",
+      "help": "Elements must have sufficient color contrast",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/color-contrast?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "color-contrast",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Element has sufficient color contrast of ${data.contrastRatio}"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input class=\"c-text-input__input\" id=\"violations__labeless-input\" type=\"text\">",
+          "target": [
+            "#violations__labeless-input"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "duplicate-id-active",
+      "impact": null,
+      "tags": [
+        "cat.parsing",
+        "wcag2a",
+        "wcag411"
+      ],
+      "description": "Ensures every id attribute value of active elements is unique",
+      "help": "IDs of active elements must be unique",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/duplicate-id-active?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "duplicate-id-active",
+              "data": "violations__empty-button",
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Document has no active elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<button data-test-selector=\"empty-button\" id=\"violations__empty-button\" class=\"c-button ember-view\">\n</button>",
+          "target": [
+            "#violations__empty-button"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id-active",
+              "data": "violations__labeless-input",
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Document has no active elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input class=\"c-text-input__input\" id=\"violations__labeless-input\" type=\"text\">",
+          "target": [
+            "#violations__labeless-input"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "duplicate-id-aria",
+      "impact": null,
+      "tags": [
+        "cat.parsing",
+        "wcag2a",
+        "wcag411"
+      ],
+      "description": "Ensures every id attribute value used in ARIA and in labels is unique",
+      "help": "IDs used in ARIA and labels must be unique",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/duplicate-id-aria?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "duplicate-id-aria",
+              "data": "noise-level-0",
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+          "target": [
+            "#noise-level-0"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id-aria",
+              "data": "noise-level-1",
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+          "target": [
+            "#noise-level-1"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id-aria",
+              "data": "noise-level-2",
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+          "target": [
+            "#noise-level-2"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id-aria",
+              "data": "noise-level-3",
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+          "target": [
+            "#noise-level-3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id-aria",
+              "data": "violations__radio-group-items--strawberries",
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+          "target": [
+            "#violations__radio-group-items--strawberries"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id-aria",
+              "data": "violations__radio-group-items--blueberries",
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+          "target": [
+            "#violations__radio-group-items--blueberries"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id-aria",
+              "data": "violations__radio-group-items--raspberries",
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+          "target": [
+            "#violations__radio-group-items--raspberries"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "duplicate-id",
+      "impact": null,
+      "tags": [
+        "cat.parsing",
+        "wcag2a",
+        "wcag411"
+      ],
+      "description": "Ensures every id attribute value is unique",
+      "help": "id attribute value must be unique",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/duplicate-id?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "ember-testing-container",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<div id=\"ember-testing-container\" style=\"visibility: visible; position: relative;\">",
+          "target": [
+            "#ember-testing-container"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "ember-testing",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<div id=\"ember-testing\" class=\"ember-application\">",
+          "target": [
+            "#ember-testing"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "ember130",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h2 data-test-selector=\"violations-page__passing-component\" id=\"ember130\" class=\"ember-view\">Violations\n</h2>",
+          "target": [
+            "#ember130"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "ember131",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<li id=\"ember131\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+          "target": [
+            "#ember131"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "ember134",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<li id=\"ember134\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+          "target": [
+            "#ember134"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "ember137",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<div data-test-selector=\"labeless-text-input\" id=\"ember137\" class=\"c-text-input ember-view\"><input class=\"c-text-input__input\" id=\"violations__labeless-input\" type=\"text\">\n</div>",
+          "target": [
+            "#ember137"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "ember138",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<li id=\"ember138\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+          "target": [
+            "#ember138"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "violations__low-contrast-text",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<p data-test-selector=\"poor-text-contrast\" id=\"violations__low-contrast-text\" class=\"p-violations__grid-item-content--low-contrast-text c-paragraph ember-view\">\n          Swoooosh\n      \n</p>",
+          "target": [
+            "#violations__low-contrast-text"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "ember141",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<li id=\"ember141\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+          "target": [
+            "#ember141"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "violations__non-standard-html",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<p data-test-selector=\"paragraph-with-blink-tag\" id=\"violations__non-standard-html\" class=\"c-paragraph ember-view\">\n        Friends don't let friends use <code>&lt;blink&gt; tags</code>, <blink>like this one!</blink>\n      \n</p>",
+          "target": [
+            "#violations__non-standard-html"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "ember142",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<li id=\"ember142\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+          "target": [
+            "#ember142"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "violations__img-without-alt",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<img src=\"assets/img/empire-state-building-moonlight.png\" id=\"violations__img-without-alt\" class=\"u-fill c-img ember-view\">",
+          "target": [
+            "#violations__img-without-alt"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "duplicate-id",
+              "data": "ember145",
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Document has no static elements that share the same id attribute"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<li id=\"ember145\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+          "target": [
+            "#ember145"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "empty-heading",
+      "impact": null,
+      "tags": [
+        "cat.name-role-value",
+        "best-practice"
+      ],
+      "description": "Ensures headings have discernible text",
+      "help": "Headings must not be empty",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/empty-heading?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "has-visible-text",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element has text that is visible to screen readers"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h1 class=\"u-align-center\">Ember A11y Testing</h1>",
+          "target": [
+            ".application__header > h1"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "has-visible-text",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element has text that is visible to screen readers"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h2 data-test-selector=\"violations-page__passing-component\" id=\"ember130\" class=\"ember-view\">Violations\n</h2>",
+          "target": [
+            "#ember130"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "has-visible-text",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element has text that is visible to screen readers"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Button without title</h3>",
+          "target": [
+            "#ember131 > .c-violations-grid-item__header > h3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "has-visible-text",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element has text that is visible to screen readers"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Input without label</h3>",
+          "target": [
+            "#ember134 > .c-violations-grid-item__header > h3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "has-visible-text",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element has text that is visible to screen readers"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Poorly Contrasting Text Color</h3>",
+          "target": [
+            "#ember138 > .c-violations-grid-item__header > h3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "has-visible-text",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element has text that is visible to screen readers"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Non-standard HTML elements</h3>",
+          "target": [
+            "#ember141 > .c-violations-grid-item__header > h3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "has-visible-text",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element has text that is visible to screen readers"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">&lt;img&gt; Tags without `alt` attributes</h3>",
+          "target": [
+            "#ember142 > .c-violations-grid-item__header > h3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "has-visible-text",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element has text that is visible to screen readers"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Ungrouped radio inputs with a shared name</h3>",
+          "target": [
+            "#ember145 > .c-violations-grid-item__header > h3"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "form-field-multiple-labels",
+      "impact": null,
+      "tags": [
+        "cat.forms",
+        "wcag2a",
+        "wcag332"
+      ],
+      "description": "Ensures form field does not have multiple label elements",
+      "help": "Form field should not have multiple label elements",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/form-field-multiple-labels?application=axeAPI",
+      "nodes": [
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "multiple-label",
+              "data": null,
+              "relatedNodes": [
+                {
+                  "html": "<label for=\"noise-level-0\" class=\"c-radio-track__radio-item\">",
+                  "target": [
+                    "label[for=\"noise-level-0\"]"
+                  ]
+                }
+              ],
+              "impact": "moderate",
+              "message": "Form field does not have multiple label elements"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+          "target": [
+            "#noise-level-0"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "multiple-label",
+              "data": null,
+              "relatedNodes": [
+                {
+                  "html": "<label for=\"noise-level-1\" class=\"c-radio-track__radio-item\">",
+                  "target": [
+                    "label[for=\"noise-level-1\"]"
+                  ]
+                }
+              ],
+              "impact": "moderate",
+              "message": "Form field does not have multiple label elements"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+          "target": [
+            "#noise-level-1"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "multiple-label",
+              "data": null,
+              "relatedNodes": [
+                {
+                  "html": "<label for=\"noise-level-2\" class=\"c-radio-track__radio-item\">",
+                  "target": [
+                    "label[for=\"noise-level-2\"]"
+                  ]
+                }
+              ],
+              "impact": "moderate",
+              "message": "Form field does not have multiple label elements"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+          "target": [
+            "#noise-level-2"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "multiple-label",
+              "data": null,
+              "relatedNodes": [
+                {
+                  "html": "<label for=\"noise-level-3\" class=\"c-radio-track__radio-item\">",
+                  "target": [
+                    "label[for=\"noise-level-3\"]"
+                  ]
+                }
+              ],
+              "impact": "moderate",
+              "message": "Form field does not have multiple label elements"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+          "target": [
+            "#noise-level-3"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "multiple-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Form field does not have multiple label elements"
+            }
+          ],
+          "impact": null,
+          "html": "<input class=\"c-text-input__input\" id=\"violations__labeless-input\" type=\"text\">",
+          "target": [
+            "#violations__labeless-input"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "multiple-label",
+              "data": null,
+              "relatedNodes": [
+                {
+                  "html": "<label class=\"u-fill-width u-align-center p-violations__grid-item-content--radio\" for=\"violations__radio-group-items--strawberries\">",
+                  "target": [
+                    ".p-violations__grid-item-content--radio.u-fill-width.u-align-center:nth-child(1)"
+                  ]
+                }
+              ],
+              "impact": "moderate",
+              "message": "Form field does not have multiple label elements"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+          "target": [
+            "#violations__radio-group-items--strawberries"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "multiple-label",
+              "data": null,
+              "relatedNodes": [
+                {
+                  "html": "<label class=\"u-fill-width u-align-center p-violations__grid-item-content--radio\" for=\"violations__radio-group-items--blueberries\">",
+                  "target": [
+                    ".p-violations__grid-item-content--radio.u-fill-width.u-align-center:nth-child(2)"
+                  ]
+                }
+              ],
+              "impact": "moderate",
+              "message": "Form field does not have multiple label elements"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+          "target": [
+            "#violations__radio-group-items--blueberries"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "multiple-label",
+              "data": null,
+              "relatedNodes": [
+                {
+                  "html": "<label class=\"u-fill-width u-align-center p-violations__grid-item-content--radio\" for=\"violations__radio-group-items--raspberries\">",
+                  "target": [
+                    ".p-violations__grid-item-content--radio.u-fill-width.u-align-center:nth-child(3)"
+                  ]
+                }
+              ],
+              "impact": "moderate",
+              "message": "Form field does not have multiple label elements"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+          "target": [
+            "#violations__radio-group-items--raspberries"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "heading-order",
+      "impact": null,
+      "tags": [
+        "cat.semantics",
+        "best-practice"
+      ],
+      "description": "Ensures the order of headings is semantically correct",
+      "help": "Heading levels should only increase by one",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/heading-order?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "heading-order",
+              "data": 1,
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Heading order valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h1 class=\"u-align-center\">Ember A11y Testing</h1>",
+          "target": [
+            ".application__header > h1"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "heading-order",
+              "data": 2,
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Heading order valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h2 data-test-selector=\"violations-page__passing-component\" id=\"ember130\" class=\"ember-view\">Violations\n</h2>",
+          "target": [
+            "#ember130"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "heading-order",
+              "data": 3,
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Heading order valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Button without title</h3>",
+          "target": [
+            "#ember131 > .c-violations-grid-item__header > h3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "heading-order",
+              "data": 3,
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Heading order valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Input without label</h3>",
+          "target": [
+            "#ember134 > .c-violations-grid-item__header > h3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "heading-order",
+              "data": 3,
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Heading order valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Poorly Contrasting Text Color</h3>",
+          "target": [
+            "#ember138 > .c-violations-grid-item__header > h3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "heading-order",
+              "data": 3,
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Heading order valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Non-standard HTML elements</h3>",
+          "target": [
+            "#ember141 > .c-violations-grid-item__header > h3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "heading-order",
+              "data": 3,
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Heading order valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">&lt;img&gt; Tags without `alt` attributes</h3>",
+          "target": [
+            "#ember142 > .c-violations-grid-item__header > h3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "heading-order",
+              "data": 3,
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Heading order valid"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Ungrouped radio inputs with a shared name</h3>",
+          "target": [
+            "#ember145 > .c-violations-grid-item__header > h3"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "identical-links-same-purpose",
+      "impact": null,
+      "tags": [
+        "wcag2aaa",
+        "wcag249",
+        "best-practice"
+      ],
+      "description": "Ensure that links with the same accessible name serve a similar purpose",
+      "help": "Links with the same name have a similar purpose",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/identical-links-same-purpose?application=axeAPI",
+      "nodes": [
+        {
+          "any": [],
+          "all": [
+            {
+              "id": "identical-links-same-purpose",
+              "data": {
+                "name": "ember a11ys bestpractices demo app",
+                "urlProps": {
+                  "protocol": "http:",
+                  "hostname": "ember-a11y.github.io",
+                  "port": "",
+                  "pathname": "/a11y-demo-app/",
+                  "search": {},
+                  "hash": "",
+                  "filename": ""
+                }
+              },
+              "relatedNodes": [
+                {
+                  "html": "<a href=\"https://ember-a11y.github.io/a11y-demo-app/\">Ember A11y's best-practices demo app</a>",
+                  "target": [
+                    "footer > a"
+                  ]
+                }
+              ],
+              "impact": "minor",
+              "message": "There are no other links with the same name, that go to a different URL"
+            }
+          ],
+          "none": [],
+          "impact": null,
+          "html": "<a href=\"https://ember-a11y.github.io/a11y-demo-app/\">Ember A11y's best-practices demo app</a>",
+          "target": [
+            "footer > a"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "image-redundant-alt",
+      "impact": null,
+      "tags": [
+        "cat.text-alternatives",
+        "best-practice"
+      ],
+      "description": "Ensure image alternative is not repeated as text",
+      "help": "Alternative text of images should not be repeated as text",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/image-redundant-alt?application=axeAPI",
+      "nodes": [
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "duplicate-img-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element does not duplicate existing text in <img> alt text"
+            }
+          ],
+          "impact": null,
+          "html": "<img src=\"assets/img/empire-state-building-moonlight.png\" id=\"violations__img-without-alt\" class=\"u-fill c-img ember-view\">",
+          "target": [
+            "#violations__img-without-alt"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "label-title-only",
+      "impact": null,
+      "tags": [
+        "cat.forms",
+        "best-practice"
+      ],
+      "description": "Ensures that every form element is not solely labeled using the title or aria-describedby attributes",
+      "help": "Form elements should have a visible label",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/label-title-only?application=axeAPI",
+      "nodes": [
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "title-only",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Form element does not solely use title attribute for its label"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+          "target": [
+            "#noise-level-0"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "title-only",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Form element does not solely use title attribute for its label"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+          "target": [
+            "#noise-level-1"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "title-only",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Form element does not solely use title attribute for its label"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+          "target": [
+            "#noise-level-2"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "title-only",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Form element does not solely use title attribute for its label"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+          "target": [
+            "#noise-level-3"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "title-only",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Form element does not solely use title attribute for its label"
+            }
+          ],
+          "impact": null,
+          "html": "<input class=\"c-text-input__input\" id=\"violations__labeless-input\" type=\"text\">",
+          "target": [
+            "#violations__labeless-input"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "title-only",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Form element does not solely use title attribute for its label"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+          "target": [
+            "#violations__radio-group-items--strawberries"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "title-only",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Form element does not solely use title attribute for its label"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+          "target": [
+            "#violations__radio-group-items--blueberries"
+          ]
+        },
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "title-only",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Form element does not solely use title attribute for its label"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+          "target": [
+            "#violations__radio-group-items--raspberries"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "label",
+      "impact": "critical",
+      "tags": [
+        "cat.forms",
+        "wcag2a",
+        "wcag412",
+        "wcag131",
+        "section508",
+        "section508.22.n"
+      ],
+      "description": "Ensures every form element has a label",
+      "help": "Form elements must have labels",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/label?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "implicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an implicit (wrapped) <label>"
+            },
+            {
+              "id": "explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an explicit <label>"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "hidden-explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has a visible explicit <label>"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+          "target": [
+            "#noise-level-0"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "implicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an implicit (wrapped) <label>"
+            },
+            {
+              "id": "explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an explicit <label>"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "hidden-explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has a visible explicit <label>"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+          "target": [
+            "#noise-level-1"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "implicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an implicit (wrapped) <label>"
+            },
+            {
+              "id": "explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an explicit <label>"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "hidden-explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has a visible explicit <label>"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+          "target": [
+            "#noise-level-2"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "implicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an implicit (wrapped) <label>"
+            },
+            {
+              "id": "explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an explicit <label>"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "hidden-explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has a visible explicit <label>"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+          "target": [
+            "#noise-level-3"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "implicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an implicit (wrapped) <label>"
+            },
+            {
+              "id": "explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an explicit <label>"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "hidden-explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has a visible explicit <label>"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+          "target": [
+            "#violations__radio-group-items--strawberries"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "implicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an implicit (wrapped) <label>"
+            },
+            {
+              "id": "explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an explicit <label>"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "hidden-explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has a visible explicit <label>"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+          "target": [
+            "#violations__radio-group-items--blueberries"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "implicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an implicit (wrapped) <label>"
+            },
+            {
+              "id": "explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has an explicit <label>"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "hidden-explicit-label",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "critical",
+              "message": "Form element has a visible explicit <label>"
+            }
+          ],
+          "impact": null,
+          "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+          "target": [
+            "#violations__radio-group-items--raspberries"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "landmark-banner-is-top-level",
+      "impact": null,
+      "tags": [
+        "cat.semantics",
+        "best-practice"
+      ],
+      "description": "Ensures the banner landmark is at top level",
+      "help": "Banner landmark must not be contained in another landmark",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-banner-is-top-level?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "landmark-is-top-level",
+              "data": {
+                "role": "banner"
+              },
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "The banner landmark is at the top level."
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<header class=\"application__header\">\n    <h1 class=\"u-align-center\">Ember A11y Testing</h1>\n  </header>",
+          "target": [
+            ".application__header"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "landmark-main-is-top-level",
+      "impact": null,
+      "tags": [
+        "cat.semantics",
+        "best-practice"
+      ],
+      "description": "Ensures the main landmark is at top level",
+      "help": "Main landmark must not be contained in another landmark",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-main-is-top-level?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "landmark-is-top-level",
+              "data": {
+                "role": "main"
+              },
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "The main landmark is at the top level."
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<main class=\"application__main-content u-relative u-fill-width o-content-box--lg\">",
+          "target": [
+            "main"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "landmark-no-duplicate-banner",
+      "impact": null,
+      "tags": [
+        "cat.semantics",
+        "best-practice"
+      ],
+      "description": "Ensures the document has at most one banner landmark",
+      "help": "Document must not have more than one banner landmark",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-no-duplicate-banner?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "page-no-duplicate-banner",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Document does not have more than one banner landmark"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<header class=\"application__header\">\n    <h1 class=\"u-align-center\">Ember A11y Testing</h1>\n  </header>",
+          "target": [
+            ".application__header"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "landmark-no-duplicate-contentinfo",
+      "impact": null,
+      "tags": [
+        "cat.semantics",
+        "best-practice"
+      ],
+      "description": "Ensures the document has at most one contentinfo landmark",
+      "help": "Document must not have more than one contentinfo landmark",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-no-duplicate-contentinfo?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "page-no-duplicate-contentinfo",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Document does not have more than one contentinfo landmark"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<footer class=\"p-violations__footer\">\n  For more on <strong>accessible</strong> user interface patterns, check out\n    <a href=\"https://ember-a11y.github.io/a11y-demo-app/\">Ember A11y's best-practices demo app</a>.\n</footer>",
+          "target": [
+            "footer"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "landmark-no-duplicate-main",
+      "impact": null,
+      "tags": [
+        "cat.semantics",
+        "best-practice"
+      ],
+      "description": "Ensures the document has at most one main landmark",
+      "help": "Document must not have more than one main landmark",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-no-duplicate-main?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "page-no-duplicate-main",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Document does not have more than one main landmark"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<main class=\"application__main-content u-relative u-fill-width o-content-box--lg\">",
+          "target": [
+            "main"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "landmark-unique",
+      "impact": null,
+      "tags": [
+        "cat.semantics",
+        "best-practice"
+      ],
+      "help": "Ensures landmarks are unique",
+      "description": "Landmarks must have a unique role or role/label/title (i.e. accessible name) combination",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-unique?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "landmark-is-unique",
+              "data": {
+                "role": "banner",
+                "accessibleText": null
+              },
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Landmarks must have a unique role or role/label/title (i.e. accessible name) combination"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<header class=\"application__header\">\n    <h1 class=\"u-align-center\">Ember A11y Testing</h1>\n  </header>",
+          "target": [
+            ".application__header"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "landmark-is-unique",
+              "data": {
+                "role": "main",
+                "accessibleText": null
+              },
+              "relatedNodes": [],
+              "impact": "moderate",
+              "message": "Landmarks must have a unique role or role/label/title (i.e. accessible name) combination"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<main class=\"application__main-content u-relative u-fill-width o-content-box--lg\">",
+          "target": [
+            "main"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "link-name",
+      "impact": null,
+      "tags": [
+        "cat.name-role-value",
+        "wcag2a",
+        "wcag412",
+        "wcag244",
+        "section508",
+        "section508.22.a"
+      ],
+      "description": "Ensures links have discernible text",
+      "help": "Links must have discernible text",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/link-name?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "has-visible-text",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "minor",
+              "message": "Element has text that is visible to screen readers"
+            }
+          ],
+          "all": [],
+          "none": [
+            {
+              "id": "focusable-no-name",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "Element is not in tab order or has accessible text"
+            }
+          ],
+          "impact": null,
+          "html": "<a href=\"https://ember-a11y.github.io/a11y-demo-app/\">Ember A11y's best-practices demo app</a>",
+          "target": [
+            "footer > a"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "list",
+      "impact": null,
+      "tags": [
+        "cat.structure",
+        "wcag2a",
+        "wcag131"
+      ],
+      "description": "Ensures that lists are structured correctly",
+      "help": "<ul> and <ol> must only directly contain <li>, <script> or <template> elements",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/list?application=axeAPI",
+      "nodes": [
+        {
+          "any": [],
+          "all": [],
+          "none": [
+            {
+              "id": "only-listitems",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "List element only has direct children that are allowed inside <li> elements"
+            }
+          ],
+          "impact": null,
+          "html": "<ul class=\"p-violations__grid u-fill-width u-relative\">",
+          "target": [
+            ".p-violations__grid"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "listitem",
+      "impact": null,
+      "tags": [
+        "cat.structure",
+        "wcag2a",
+        "wcag131"
+      ],
+      "description": "Ensures <li> elements are used semantically",
+      "help": "<li> elements must be contained in a <ul> or <ol>",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/listitem?application=axeAPI",
+      "nodes": [
+        {
+          "any": [
+            {
+              "id": "listitem",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "List item has a <ul>, <ol> or role=\"list\" parent element"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<li id=\"ember131\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+          "target": [
+            "#ember131"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "listitem",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "List item has a <ul>, <ol> or role=\"list\" parent element"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<li id=\"ember134\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+          "target": [
+            "#ember134"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "listitem",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "List item has a <ul>, <ol> or role=\"list\" parent element"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<li id=\"ember138\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+          "target": [
+            "#ember138"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "listitem",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "List item has a <ul>, <ol> or role=\"list\" parent element"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<li id=\"ember141\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+          "target": [
+            "#ember141"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "listitem",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "List item has a <ul>, <ol> or role=\"list\" parent element"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<li id=\"ember142\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+          "target": [
+            "#ember142"
+          ]
+        },
+        {
+          "any": [
+            {
+              "id": "listitem",
+              "data": null,
+              "relatedNodes": [],
+              "impact": "serious",
+              "message": "List item has a <ul>, <ol> or role=\"list\" parent element"
+            }
+          ],
+          "all": [],
+          "none": [],
+          "impact": null,
+          "html": "<li id=\"ember145\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+          "target": [
+            "#ember145"
+          ]
+        }
+      ]
+    }
+  ],
+  "incomplete": [],
+  "inapplicable": [
+    {
+      "id": "accesskeys",
+      "impact": null,
+      "tags": [
+        "best-practice",
+        "cat.keyboard"
+      ],
+      "description": "Ensures every accesskey attribute value is unique",
+      "help": "accesskey attribute value must be unique",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/accesskeys?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "area-alt",
+      "impact": null,
+      "tags": [
+        "cat.text-alternatives",
+        "wcag2a",
+        "wcag111",
+        "wcag244",
+        "wcag412",
+        "section508",
+        "section508.22.a"
+      ],
+      "description": "Ensures <area> elements of image maps have alternate text",
+      "help": "Active <area> elements must have alternate text",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/area-alt?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "aria-allowed-role",
+      "impact": null,
+      "tags": [
+        "cat.aria",
+        "best-practice"
+      ],
+      "description": "Ensures role attribute has an appropriate value for the element",
+      "help": "ARIA role must be appropriate for the element",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-allowed-role?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "aria-hidden-body",
+      "impact": null,
+      "tags": [
+        "cat.aria",
+        "wcag2a",
+        "wcag412"
+      ],
+      "description": "Ensures aria-hidden='true' is not present on the document body.",
+      "help": "aria-hidden='true' must not be present on the document body",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-hidden-body?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "aria-hidden-focus",
+      "impact": null,
+      "tags": [
+        "cat.name-role-value",
+        "wcag2a",
+        "wcag412",
+        "wcag131"
+      ],
+      "description": "Ensures aria-hidden elements do not contain focusable elements",
+      "help": "ARIA hidden element must not contain focusable elements",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-hidden-focus?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "aria-input-field-name",
+      "impact": null,
+      "tags": [
+        "wcag2a",
+        "wcag412"
+      ],
+      "description": "Ensures every ARIA input field has an accessible name",
+      "help": "ARIA input fields must have an accessible name",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-input-field-name?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "aria-required-attr",
+      "impact": null,
+      "tags": [
+        "cat.aria",
+        "wcag2a",
+        "wcag412"
+      ],
+      "description": "Ensures elements with ARIA roles have all required ARIA attributes",
+      "help": "Required ARIA attributes must be provided",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-required-attr?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "aria-required-children",
+      "impact": null,
+      "tags": [
+        "cat.aria",
+        "wcag2a",
+        "wcag131"
+      ],
+      "description": "Ensures elements with an ARIA role that require child roles contain them",
+      "help": "Certain ARIA roles must contain particular children",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-required-children?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "aria-required-parent",
+      "impact": null,
+      "tags": [
+        "cat.aria",
+        "wcag2a",
+        "wcag131"
+      ],
+      "description": "Ensures elements with an ARIA role that require parent roles are contained by them",
+      "help": "Certain ARIA roles must be contained by particular parents",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-required-parent?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "aria-roledescription",
+      "impact": null,
+      "tags": [
+        "cat.aria",
+        "wcag2a",
+        "wcag412"
+      ],
+      "description": "Ensure aria-roledescription is only used on elements with an implicit or explicit role",
+      "help": "Use aria-roledescription on elements with a semantic role",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-roledescription?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "aria-roles",
+      "impact": null,
+      "tags": [
+        "cat.aria",
+        "wcag2a",
+        "wcag412"
+      ],
+      "description": "Ensures all elements with a role attribute use a valid value",
+      "help": "ARIA roles used must conform to valid values",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-roles?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "aria-toggle-field-name",
+      "impact": null,
+      "tags": [
+        "wcag2a",
+        "wcag412"
+      ],
+      "description": "Ensures every ARIA toggle field has an accessible name",
+      "help": "ARIA toggle fields have an accessible name",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-toggle-field-name?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "autocomplete-valid",
+      "impact": null,
+      "tags": [
+        "cat.forms",
+        "wcag21aa",
+        "wcag135"
+      ],
+      "description": "Ensure the autocomplete attribute is correct and suitable for the form field",
+      "help": "autocomplete attribute must be used correctly",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/autocomplete-valid?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "definition-list",
+      "impact": null,
+      "tags": [
+        "cat.structure",
+        "wcag2a",
+        "wcag131"
+      ],
+      "description": "Ensures <dl> elements are structured correctly",
+      "help": "<dl> elements must only directly contain properly-ordered <dt> and <dd> groups, <script>, <template> or <div> elements",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/definition-list?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "dlitem",
+      "impact": null,
+      "tags": [
+        "cat.structure",
+        "wcag2a",
+        "wcag131"
+      ],
+      "description": "Ensures <dt> and <dd> elements are contained by a <dl>",
+      "help": "<dt> and <dd> elements must be contained by a <dl>",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/dlitem?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "document-title",
+      "impact": null,
+      "tags": [
+        "cat.text-alternatives",
+        "wcag2a",
+        "wcag242",
+        "ACT"
+      ],
+      "description": "Ensures each HTML document contains a non-empty <title> element",
+      "help": "Documents must have <title> element to aid in navigation",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/document-title?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "frame-tested",
+      "impact": null,
+      "tags": [
+        "cat.structure",
+        "review-item",
+        "best-practice"
+      ],
+      "description": "Ensures <iframe> and <frame> elements contain the axe-core script",
+      "help": "Frames must be tested with axe-core",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/frame-tested?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "frame-title-unique",
+      "impact": null,
+      "tags": [
+        "cat.text-alternatives",
+        "best-practice"
+      ],
+      "description": "Ensures <iframe> and <frame> elements contain a unique title attribute",
+      "help": "Frames must have a unique title attribute",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/frame-title-unique?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "frame-title",
+      "impact": null,
+      "tags": [
+        "cat.text-alternatives",
+        "wcag2a",
+        "wcag241",
+        "wcag412",
+        "section508",
+        "section508.22.i"
+      ],
+      "description": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
+      "help": "Frames must have title attribute",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/frame-title?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "html-has-lang",
+      "impact": null,
+      "tags": [
+        "cat.language",
+        "wcag2a",
+        "wcag311",
+        "ACT"
+      ],
+      "description": "Ensures every HTML document has a lang attribute",
+      "help": "<html> element must have a lang attribute",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/html-has-lang?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "html-lang-valid",
+      "impact": null,
+      "tags": [
+        "cat.language",
+        "wcag2a",
+        "wcag311",
+        "ACT"
+      ],
+      "description": "Ensures the lang attribute of the <html> element has a valid value",
+      "help": "<html> element must have a valid value for the lang attribute",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/html-lang-valid?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "html-xml-lang-mismatch",
+      "impact": null,
+      "tags": [
+        "cat.language",
+        "wcag2a",
+        "wcag311",
+        "ACT"
+      ],
+      "description": "Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page",
+      "help": "HTML elements with lang and xml:lang must have the same base language",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/html-xml-lang-mismatch?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "input-button-name",
+      "impact": null,
+      "tags": [
+        "cat.name-role-value",
+        "wcag2a",
+        "wcag412",
+        "section508",
+        "section508.22.a"
+      ],
+      "description": "Ensures input buttons have discernible text",
+      "help": "Input buttons must have discernible text",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/input-button-name?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "input-image-alt",
+      "impact": null,
+      "tags": [
+        "cat.text-alternatives",
+        "wcag2a",
+        "wcag111",
+        "section508",
+        "section508.22.a",
+        "ACT"
+      ],
+      "description": "Ensures <input type=\"image\"> elements have alternate text",
+      "help": "Image buttons must have alternate text",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/input-image-alt?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "landmark-complementary-is-top-level",
+      "impact": null,
+      "tags": [
+        "cat.semantics",
+        "best-practice"
+      ],
+      "description": "Ensures the complementary landmark or aside is at top level",
+      "help": "Aside must not be contained in another landmark",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-complementary-is-top-level?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "landmark-contentinfo-is-top-level",
+      "impact": null,
+      "tags": [
+        "cat.semantics",
+        "best-practice"
+      ],
+      "description": "Ensures the contentinfo landmark is at top level",
+      "help": "Contentinfo landmark must not be contained in another landmark",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-contentinfo-is-top-level?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "landmark-one-main",
+      "impact": null,
+      "tags": [
+        "cat.semantics",
+        "best-practice"
+      ],
+      "description": "Ensures the document has a main landmark",
+      "help": "Document must have one main landmark",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-one-main?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "marquee",
+      "impact": null,
+      "tags": [
+        "cat.parsing",
+        "wcag2a",
+        "wcag222"
+      ],
+      "description": "Ensures <marquee> elements are not used",
+      "help": "<marquee> elements are deprecated and must not be used",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/marquee?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "meta-refresh",
+      "impact": null,
+      "tags": [
+        "cat.time-and-media",
+        "wcag2a",
+        "wcag2aaa",
+        "wcag221",
+        "wcag224",
+        "wcag325"
+      ],
+      "description": "Ensures <meta http-equiv=\"refresh\"> is not used",
+      "help": "Timed refresh must not exist",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/meta-refresh?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "meta-viewport-large",
+      "impact": null,
+      "tags": [
+        "cat.sensory-and-visual-cues",
+        "best-practice"
+      ],
+      "description": "Ensures <meta name=\"viewport\"> can scale a significant amount",
+      "help": "Users should be able to zoom and scale the text up to 500%",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/meta-viewport-large?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "meta-viewport",
+      "impact": null,
+      "tags": [
+        "cat.sensory-and-visual-cues",
+        "best-practice"
+      ],
+      "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+      "help": "Zooming and scaling must not be disabled",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/meta-viewport?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "object-alt",
+      "impact": null,
+      "tags": [
+        "cat.text-alternatives",
+        "wcag2a",
+        "wcag111",
+        "section508",
+        "section508.22.a"
+      ],
+      "description": "Ensures <object> elements have alternate text",
+      "help": "<object> elements must have alternate text",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/object-alt?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "page-has-heading-one",
+      "impact": null,
+      "tags": [
+        "cat.semantics",
+        "best-practice"
+      ],
+      "description": "Ensure that the page, or at least one of its frames contains a level-one heading",
+      "help": "Page must contain a level-one heading",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/page-has-heading-one?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "region",
+      "impact": null,
+      "tags": [
+        "cat.keyboard",
+        "best-practice"
+      ],
+      "description": "Ensures all page content is contained by landmarks",
+      "help": "All page content must be contained by landmarks",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/region?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "role-img-alt",
+      "impact": null,
+      "tags": [
+        "cat.text-alternatives",
+        "wcag2a",
+        "wcag111",
+        "section508",
+        "section508.22.a"
+      ],
+      "description": "Ensures [role='img'] elements have alternate text",
+      "help": "[role='img'] elements have an alternative text",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/role-img-alt?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "scope-attr-valid",
+      "impact": null,
+      "tags": [
+        "cat.tables",
+        "best-practice"
+      ],
+      "description": "Ensures the scope attribute is used correctly on tables",
+      "help": "scope attribute should be used correctly",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/scope-attr-valid?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "scrollable-region-focusable",
+      "impact": null,
+      "tags": [
+        "wcag2a",
+        "wcag211"
+      ],
+      "description": "Elements that have scrollable content should be accessible by keyboard",
+      "help": "Ensure that scrollable region has keyboard access",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/scrollable-region-focusable?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "server-side-image-map",
+      "impact": null,
+      "tags": [
+        "cat.text-alternatives",
+        "wcag2a",
+        "wcag211",
+        "section508",
+        "section508.22.f"
+      ],
+      "description": "Ensures that server-side image maps are not used",
+      "help": "Server-side image maps must not be used",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/server-side-image-map?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "skip-link",
+      "impact": null,
+      "tags": [
+        "cat.keyboard",
+        "best-practice"
+      ],
+      "description": "Ensure all skip links have a focusable target",
+      "help": "The skip-link target should exist and be focusable",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/skip-link?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "svg-img-alt",
+      "impact": null,
+      "tags": [
+        "cat.text-alternatives",
+        "wcag2a",
+        "wcag111",
+        "section508",
+        "section508.22.a"
+      ],
+      "description": "Ensures svg elements with an img, graphics-document or graphics-symbol role have an accessible text",
+      "help": "svg elements with an img role have an alternative text",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/svg-img-alt?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "tabindex",
+      "impact": null,
+      "tags": [
+        "cat.keyboard",
+        "best-practice"
+      ],
+      "description": "Ensures tabindex attribute values are not greater than 0",
+      "help": "Elements should not have tabindex greater than zero",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/tabindex?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "table-duplicate-name",
+      "impact": null,
+      "tags": [
+        "cat.tables",
+        "best-practice"
+      ],
+      "description": "Ensure that tables do not have the same summary and caption",
+      "help": "The <caption> element should not contain the same text as the summary attribute",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/table-duplicate-name?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "td-headers-attr",
+      "impact": null,
+      "tags": [
+        "cat.tables",
+        "wcag2a",
+        "wcag131",
+        "section508",
+        "section508.22.g"
+      ],
+      "description": "Ensure that each cell in a table using the headers refers to another cell in that table",
+      "help": "All cells in a table element that use the headers attribute must only refer to other cells of that same table",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/td-headers-attr?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "th-has-data-cells",
+      "impact": null,
+      "tags": [
+        "cat.tables",
+        "wcag2a",
+        "wcag131",
+        "section508",
+        "section508.22.g"
+      ],
+      "description": "Ensure that each table header in a data table refers to data cells",
+      "help": "All th elements and elements with role=columnheader/rowheader must have data cells they describe",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/th-has-data-cells?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "valid-lang",
+      "impact": null,
+      "tags": [
+        "cat.language",
+        "wcag2aa",
+        "wcag312"
+      ],
+      "description": "Ensures lang attributes have valid values",
+      "help": "lang attribute must have a valid value",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/valid-lang?application=axeAPI",
+      "nodes": []
+    },
+    {
+      "id": "video-caption",
+      "impact": null,
+      "tags": [
+        "cat.text-alternatives",
+        "wcag2a",
+        "wcag122",
+        "section508",
+        "section508.22.a"
+      ],
+      "description": "Ensures <video> elements have captions",
+      "help": "<video> elements must have captions",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/video-caption?application=axeAPI",
+      "nodes": []
+    }
+  ]
+}

--- a/node-tests/setup-middleware-test.js
+++ b/node-tests/setup-middleware-test.js
@@ -44,7 +44,7 @@ QUnit.module('setupMiddleware', function (hooks) {
   QUnit.test('can respond to requests to report violations', async function (
     assert
   ) {
-    let data = buildResult(violationsFixture);
+    let data = [buildResult(violationsFixture)];
 
     let json = await fetch('http://localhost:3000/report-violations', {
       method: 'POST',

--- a/node-tests/setup-middleware-test.js
+++ b/node-tests/setup-middleware-test.js
@@ -1,0 +1,59 @@
+const QUnit = require('qunit');
+const fetch = require('node-fetch');
+const fs = require('fs');
+const tmp = require('tmp');
+const express = require('express');
+const readJSONSync = require('fs-extra').readJSONSync;
+const setupMiddleware = require('../setup-middleware');
+const violationsFixture = require('./fixtures/violations');
+
+function createTmpDir() {
+  return fs.realpathSync(tmp.dirSync({ unsafeCleanup: true }).name);
+}
+
+function buildResult(axeResults) {
+  let { module, testName } = QUnit.config.current;
+
+  return {
+    moduleName: module.name,
+    testName,
+    helperName: 'visit',
+    stack: 'STACK',
+    axeResults,
+  };
+}
+
+QUnit.module('setupMiddleware', function (hooks) {
+  let tmpDir;
+  let app;
+  let server;
+
+  hooks.beforeEach(function () {
+    tmpDir = createTmpDir();
+    app = express();
+
+    setupMiddleware(app, { root: tmpDir });
+
+    server = app.listen(3000);
+  });
+
+  hooks.afterEach(function () {
+    server.close();
+  });
+
+  QUnit.test('can respond to requests to report violations', async function (
+    assert
+  ) {
+    let data = buildResult(violationsFixture);
+
+    let json = await fetch('http://localhost:3000/report-violations', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    }).then((res) => res.json());
+
+    assert.deepEqual(readJSONSync(json.outputPath), data);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint:js": "eslint .",
     "start": "ember serve",
     "test": "npm-run-all lint:* test:*",
+    "test:node": "qunit node-tests",
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each",
     "prepublishOnly": "ember ts:precompile",
@@ -30,12 +31,15 @@
   },
   "dependencies": {
     "axe-core": "^4.0.1",
+    "body-parser": "^1.19.0",
     "broccoli-funnel": "^3.0.3",
     "broccoli-merge-trees": "^4.2.0",
+    "date-and-time": "^0.14.1",
     "ember-cli-babel": "^7.21.0",
     "ember-cli-typescript": "^4.0.0",
     "ember-cli-version-checker": "^5.1.1",
-    "ember-destroyable-polyfill": "^2.0.1"
+    "ember-destroyable-polyfill": "^2.0.1",
+    "fs-extra": "^9.0.1"
   },
   "devDependencies": {
     "@ember/jquery": "^1.1.0",
@@ -80,7 +84,9 @@
     "eslint-plugin-ember": "^9.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "express": "^4.17.1",
     "loader.js": "^4.7.0",
+    "node-fetch": "^2.6.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "qunit": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "release-it": "^14.0.0",
     "release-it-lerna-changelog": "^2.3.0",
     "sass": "^1.26.10",
+    "tmp": "^0.2.1",
     "typescript": "^4.0.0"
   },
   "engines": {

--- a/setup-middleware.js
+++ b/setup-middleware.js
@@ -1,15 +1,18 @@
 'use strict';
 
 const bodyParser = require('body-parser').json({ limit: '50mb' });
-const writeJsonSync = require('fs-extra').writeJSONSync;
 const path = require('path');
 const date = require('date-and-time');
+const { ensureDirSync, writeJsonSync } = require('fs-extra');
 
 function reportViolations(req, res, options) {
   const REPORT_TIMESTAMP = date.format(new Date(), 'YYYY-MM-DD-HH_mm_ss');
+  let outputDir = path.join(options.root, 'ember-a11y-report');
   let outputPath = path.resolve(
-    path.join(options.root, 'ember-a11y-report', `${REPORT_TIMESTAMP}.json`)
+    path.join(outputDir, `${REPORT_TIMESTAMP}.json`)
   );
+
+  ensureDirSync(outputDir);
   writeJsonSync(outputPath, req.body);
 
   res.send({

--- a/setup-middleware.js
+++ b/setup-middleware.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const bodyParser = require('body-parser').json({ limit: '50mb' });
+const writeJsonSync = require('fs-extra').writeJSONSync;
+const path = require('path');
+const date = require('date-and-time');
+
+function reportViolations(req, res, options) {
+  const REPORT_TIMESTAMP = date.format(new Date(), 'YYYY-MM-DD-HH_mm_ss');
+  let outputPath = path.resolve(
+    path.join(options.root, 'ember-a11y-report', `${REPORT_TIMESTAMP}.json`)
+  );
+  writeJsonSync(outputPath, req.body);
+
+  res.send({
+    outputPath,
+  });
+}
+
+function logError(err, req, res, next) {
+  console.error(err.stack);
+  next(err);
+}
+
+function setupMiddleware(app, options) {
+  app.post(
+    '/report-violations',
+    bodyParser,
+    (req, res) => {
+      reportViolations(req, res, options);
+    },
+    logError
+  );
+}
+
+module.exports = setupMiddleware;

--- a/tests/acceptance/setup-middleware-reporter-test.ts
+++ b/tests/acceptance/setup-middleware-reporter-test.ts
@@ -1,0 +1,39 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@ember/test-helpers';
+import {
+  setCustomReporter,
+  setEnableA11yAudit,
+  setupGlobalA11yHooks,
+  teardownGlobalA11yHooks,
+  _middlewareReporter,
+  _TEST_SUITE_RESULTS,
+} from 'ember-a11y-testing/test-support';
+
+module('setupMiddlewareReporter', function (hooks) {
+  setupApplicationTest(hooks);
+
+  function invokeAll(): boolean {
+    return true;
+  }
+
+  hooks.beforeEach(function () {
+    setCustomReporter(_middlewareReporter);
+    setupGlobalA11yHooks(invokeAll);
+    setEnableA11yAudit(true);
+  });
+
+  hooks.afterEach(function () {
+    setCustomReporter();
+    teardownGlobalA11yHooks();
+    setEnableA11yAudit();
+  });
+
+  test('gathers results from failed a11yAudit calls', async function (assert) {
+    assert.expect(1);
+
+    await visit('/');
+
+    assert.deepEqual(_TEST_SUITE_RESULTS[0].axeResults.violations.length, 3);
+  });
+});

--- a/tests/fixtures/violations.json
+++ b/tests/fixtures/violations.json
@@ -1,0 +1,3333 @@
+[
+  {
+    "moduleName": "setupMiddlewareReporter",
+    "testName": "gathers results from failed a11yAudit calls",
+    "helperName": "visit",
+    "stack": "",
+    "axeResults": {
+      "testEngine": {
+        "name": "axe-core",
+        "version": "4.0.1"
+      },
+      "testRunner": {
+        "name": "axe"
+      },
+      "testEnvironment": {
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36",
+        "windowWidth": 2030,
+        "windowHeight": 933,
+        "orientationAngle": 0,
+        "orientationType": "landscape-primary"
+      },
+      "timestamp": "2020-09-04T23:32:13.625Z",
+      "url": "http://localhost:4200/tests/index.html?testId=7541800d&enableA11yAudit=",
+      "toolOptions": {
+        "reporter": "v1"
+      },
+      "violations": [
+        {
+          "id": "button-name",
+          "impact": "critical",
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a"
+          ],
+          "description": "Ensures buttons have discernible text",
+          "help": "Buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/button-name?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "button-has-visible-text",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Element does not have inner text that is visible to screen readers"
+                },
+                {
+                  "id": "aria-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "aria-label attribute does not exist or is empty"
+                },
+                {
+                  "id": "aria-labelledby",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty"
+                },
+                {
+                  "id": "role-presentation",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element's default semantics were not overridden with role=\"presentation\""
+                },
+                {
+                  "id": "role-none",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element's default semantics were not overridden with role=\"none\""
+                },
+                {
+                  "id": "non-empty-title",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Element has no title attribute or the title attribute is empty"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": "critical",
+              "html": "<button data-test-selector=\"empty-button\" id=\"violations__empty-button\" class=\"c-button ember-view\">\n</button>",
+              "target": [
+                "#violations__empty-button"
+              ],
+              "failureSummary": "Fix any of the following:\n  Element does not have inner text that is visible to screen readers\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\"\n  Element has no title attribute or the title attribute is empty"
+            }
+          ]
+        },
+        {
+          "id": "image-alt",
+          "impact": "critical",
+          "tags": [
+            "cat.text-alternatives",
+            "wcag2a",
+            "wcag111",
+            "section508",
+            "section508.22.a"
+          ],
+          "description": "Ensures <img> elements have alternate text or a role of none or presentation",
+          "help": "Images must have alternate text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/image-alt?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "has-alt",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Element does not have an alt attribute"
+                },
+                {
+                  "id": "aria-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "aria-label attribute does not exist or is empty"
+                },
+                {
+                  "id": "aria-labelledby",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty"
+                },
+                {
+                  "id": "non-empty-title",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Element has no title attribute or the title attribute is empty"
+                },
+                {
+                  "id": "role-presentation",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element's default semantics were not overridden with role=\"presentation\""
+                },
+                {
+                  "id": "role-none",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element's default semantics were not overridden with role=\"none\""
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": "critical",
+              "html": "<img src=\"assets/img/empire-state-building-moonlight.png\" id=\"violations__img-without-alt\" class=\"u-fill c-img ember-view\">",
+              "target": [
+                "#violations__img-without-alt"
+              ],
+              "failureSummary": "Fix any of the following:\n  Element does not have an alt attribute\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Element has no title attribute or the title attribute is empty\n  Element's default semantics were not overridden with role=\"presentation\"\n  Element's default semantics were not overridden with role=\"none\""
+            }
+          ]
+        },
+        {
+          "id": "label",
+          "impact": "critical",
+          "tags": [
+            "cat.forms",
+            "wcag2a",
+            "wcag412",
+            "wcag131",
+            "section508",
+            "section508.22.n"
+          ],
+          "description": "Ensures every form element has a label",
+          "help": "Form elements must have labels",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/label?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "aria-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "aria-label attribute does not exist or is empty"
+                },
+                {
+                  "id": "aria-labelledby",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty"
+                },
+                {
+                  "id": "implicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element does not have an implicit (wrapped) <label>"
+                },
+                {
+                  "id": "explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element does not have an explicit <label>"
+                },
+                {
+                  "id": "non-empty-title",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Element has no title attribute or the title attribute is empty"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": "critical",
+              "html": "<input class=\"c-text-input__input\" id=\"violations__labeless-input\" type=\"text\">",
+              "target": [
+                "#violations__labeless-input"
+              ],
+              "failureSummary": "Fix any of the following:\n  aria-label attribute does not exist or is empty\n  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n  Form element does not have an implicit (wrapped) <label>\n  Form element does not have an explicit <label>\n  Element has no title attribute or the title attribute is empty"
+            }
+          ]
+        }
+      ],
+      "passes": [
+        {
+          "id": "aria-allowed-attr",
+          "impact": null,
+          "tags": [
+            "cat.aria",
+            "wcag2a",
+            "wcag412"
+          ],
+          "description": "Ensures ARIA attributes are allowed for an element's role",
+          "help": "Elements must only use allowed ARIA attributes",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-allowed-attr?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "aria-allowed-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attributes are used correctly for the defined role"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "aria-unsupported-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute is supported"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+              "target": [
+                "#noise-level-0"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "aria-allowed-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attributes are used correctly for the defined role"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "aria-unsupported-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute is supported"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+              "target": [
+                "#noise-level-1"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "aria-allowed-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attributes are used correctly for the defined role"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "aria-unsupported-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute is supported"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+              "target": [
+                "#noise-level-2"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "aria-allowed-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attributes are used correctly for the defined role"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "aria-unsupported-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute is supported"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+              "target": [
+                "#noise-level-3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "aria-allowed-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attributes are used correctly for the defined role"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "aria-unsupported-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute is supported"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+              "target": [
+                "#violations__radio-group-items--strawberries"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "aria-allowed-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attributes are used correctly for the defined role"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "aria-unsupported-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute is supported"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+              "target": [
+                "#violations__radio-group-items--blueberries"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "aria-allowed-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attributes are used correctly for the defined role"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "aria-unsupported-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute is supported"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+              "target": [
+                "#violations__radio-group-items--raspberries"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "aria-valid-attr-value",
+          "impact": null,
+          "tags": [
+            "cat.aria",
+            "wcag2a",
+            "wcag412"
+          ],
+          "description": "Ensures all ARIA attributes have valid values",
+          "help": "ARIA attributes must conform to valid values",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-valid-attr-value?application=axeAPI",
+          "nodes": [
+            {
+              "any": [],
+              "all": [
+                {
+                  "id": "aria-valid-attr-value",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute values are valid"
+                },
+                {
+                  "id": "aria-errormessage",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Uses a supported aria-errormessage technique"
+                }
+              ],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+              "target": [
+                "#noise-level-0"
+              ]
+            },
+            {
+              "any": [],
+              "all": [
+                {
+                  "id": "aria-valid-attr-value",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute values are valid"
+                },
+                {
+                  "id": "aria-errormessage",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Uses a supported aria-errormessage technique"
+                }
+              ],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+              "target": [
+                "#noise-level-1"
+              ]
+            },
+            {
+              "any": [],
+              "all": [
+                {
+                  "id": "aria-valid-attr-value",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute values are valid"
+                },
+                {
+                  "id": "aria-errormessage",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Uses a supported aria-errormessage technique"
+                }
+              ],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+              "target": [
+                "#noise-level-2"
+              ]
+            },
+            {
+              "any": [],
+              "all": [
+                {
+                  "id": "aria-valid-attr-value",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute values are valid"
+                },
+                {
+                  "id": "aria-errormessage",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Uses a supported aria-errormessage technique"
+                }
+              ],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+              "target": [
+                "#noise-level-3"
+              ]
+            },
+            {
+              "any": [],
+              "all": [
+                {
+                  "id": "aria-valid-attr-value",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute values are valid"
+                },
+                {
+                  "id": "aria-errormessage",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Uses a supported aria-errormessage technique"
+                }
+              ],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+              "target": [
+                "#violations__radio-group-items--strawberries"
+              ]
+            },
+            {
+              "any": [],
+              "all": [
+                {
+                  "id": "aria-valid-attr-value",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute values are valid"
+                },
+                {
+                  "id": "aria-errormessage",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Uses a supported aria-errormessage technique"
+                }
+              ],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+              "target": [
+                "#violations__radio-group-items--blueberries"
+              ]
+            },
+            {
+              "any": [],
+              "all": [
+                {
+                  "id": "aria-valid-attr-value",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute values are valid"
+                },
+                {
+                  "id": "aria-errormessage",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Uses a supported aria-errormessage technique"
+                }
+              ],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+              "target": [
+                "#violations__radio-group-items--raspberries"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "aria-valid-attr",
+          "impact": null,
+          "tags": [
+            "cat.aria",
+            "wcag2a",
+            "wcag412"
+          ],
+          "description": "Ensures attributes that begin with aria- are valid ARIA attributes",
+          "help": "ARIA attributes must conform to valid names",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-valid-attr?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "aria-valid-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute name is valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+              "target": [
+                "#noise-level-0"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "aria-valid-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute name is valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+              "target": [
+                "#noise-level-1"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "aria-valid-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute name is valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+              "target": [
+                "#noise-level-2"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "aria-valid-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute name is valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+              "target": [
+                "#noise-level-3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "aria-valid-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute name is valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+              "target": [
+                "#violations__radio-group-items--strawberries"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "aria-valid-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute name is valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+              "target": [
+                "#violations__radio-group-items--blueberries"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "aria-valid-attr",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "ARIA attribute name is valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+              "target": [
+                "#violations__radio-group-items--raspberries"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "avoid-inline-spacing",
+          "impact": null,
+          "tags": [
+            "wcag21aa",
+            "wcag1412"
+          ],
+          "description": "Ensure that text spacing set through style attributes can be adjusted with custom stylesheets",
+          "help": "Inline text spacing must be adjustable with custom stylesheets",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/avoid-inline-spacing?application=axeAPI",
+          "nodes": [
+            {
+              "any": [],
+              "all": [
+                {
+                  "id": "avoid-inline-spacing",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "No inline styles with '!important' that affect text spacing has been specified"
+                }
+              ],
+              "none": [],
+              "impact": null,
+              "html": "<div id=\"ember-testing-container\" style=\"visibility: visible; position: relative;\">",
+              "target": [
+                "#ember-testing-container"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "blink",
+          "impact": null,
+          "tags": [
+            "cat.time-and-media",
+            "wcag2a",
+            "wcag222",
+            "section508",
+            "section508.22.j"
+          ],
+          "description": "Ensures <blink> elements are not used",
+          "help": "<blink> elements are deprecated and must not be used",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/blink?application=axeAPI",
+          "nodes": [
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "is-on-screen",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Element is not visible"
+                }
+              ],
+              "impact": null,
+              "html": "<blink>like this one!</blink>",
+              "target": [
+                "blink"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "color-contrast",
+          "impact": null,
+          "tags": [
+            "cat.color",
+            "wcag2aa",
+            "wcag143"
+          ],
+          "description": "Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds",
+          "help": "Elements must have sufficient color contrast",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/color-contrast?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "color-contrast",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Element has sufficient color contrast of ${data.contrastRatio}"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input class=\"c-text-input__input\" id=\"violations__labeless-input\" type=\"text\">",
+              "target": [
+                "#violations__labeless-input"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "duplicate-id-active",
+          "impact": null,
+          "tags": [
+            "cat.parsing",
+            "wcag2a",
+            "wcag411"
+          ],
+          "description": "Ensures every id attribute value of active elements is unique",
+          "help": "IDs of active elements must be unique",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/duplicate-id-active?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "duplicate-id-active",
+                  "data": "violations__empty-button",
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Document has no active elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<button data-test-selector=\"empty-button\" id=\"violations__empty-button\" class=\"c-button ember-view\">\n</button>",
+              "target": [
+                "#violations__empty-button"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id-active",
+                  "data": "violations__labeless-input",
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Document has no active elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input class=\"c-text-input__input\" id=\"violations__labeless-input\" type=\"text\">",
+              "target": [
+                "#violations__labeless-input"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "duplicate-id-aria",
+          "impact": null,
+          "tags": [
+            "cat.parsing",
+            "wcag2a",
+            "wcag411"
+          ],
+          "description": "Ensures every id attribute value used in ARIA and in labels is unique",
+          "help": "IDs used in ARIA and labels must be unique",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/duplicate-id-aria?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "duplicate-id-aria",
+                  "data": "noise-level-0",
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+              "target": [
+                "#noise-level-0"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id-aria",
+                  "data": "noise-level-1",
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+              "target": [
+                "#noise-level-1"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id-aria",
+                  "data": "noise-level-2",
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+              "target": [
+                "#noise-level-2"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id-aria",
+                  "data": "noise-level-3",
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+              "target": [
+                "#noise-level-3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id-aria",
+                  "data": "violations__radio-group-items--strawberries",
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+              "target": [
+                "#violations__radio-group-items--strawberries"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id-aria",
+                  "data": "violations__radio-group-items--blueberries",
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+              "target": [
+                "#violations__radio-group-items--blueberries"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id-aria",
+                  "data": "violations__radio-group-items--raspberries",
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Document has no elements referenced with ARIA or labels that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+              "target": [
+                "#violations__radio-group-items--raspberries"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "duplicate-id",
+          "impact": null,
+          "tags": [
+            "cat.parsing",
+            "wcag2a",
+            "wcag411"
+          ],
+          "description": "Ensures every id attribute value is unique",
+          "help": "id attribute value must be unique",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/duplicate-id?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "ember-testing-container",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<div id=\"ember-testing-container\" style=\"visibility: visible; position: relative;\">",
+              "target": [
+                "#ember-testing-container"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "ember-testing",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<div id=\"ember-testing\" class=\"ember-application\">",
+              "target": [
+                "#ember-testing"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "ember130",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h2 data-test-selector=\"violations-page__passing-component\" id=\"ember130\" class=\"ember-view\">Violations\n</h2>",
+              "target": [
+                "#ember130"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "ember131",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<li id=\"ember131\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+              "target": [
+                "#ember131"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "ember134",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<li id=\"ember134\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+              "target": [
+                "#ember134"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "ember137",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<div data-test-selector=\"labeless-text-input\" id=\"ember137\" class=\"c-text-input ember-view\"><input class=\"c-text-input__input\" id=\"violations__labeless-input\" type=\"text\">\n</div>",
+              "target": [
+                "#ember137"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "ember138",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<li id=\"ember138\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+              "target": [
+                "#ember138"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "violations__low-contrast-text",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<p data-test-selector=\"poor-text-contrast\" id=\"violations__low-contrast-text\" class=\"p-violations__grid-item-content--low-contrast-text c-paragraph ember-view\">\n          Swoooosh\n      \n</p>",
+              "target": [
+                "#violations__low-contrast-text"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "ember141",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<li id=\"ember141\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+              "target": [
+                "#ember141"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "violations__non-standard-html",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<p data-test-selector=\"paragraph-with-blink-tag\" id=\"violations__non-standard-html\" class=\"c-paragraph ember-view\">\n        Friends don't let friends use <code>&lt;blink&gt; tags</code>, <blink>like this one!</blink>\n      \n</p>",
+              "target": [
+                "#violations__non-standard-html"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "ember142",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<li id=\"ember142\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+              "target": [
+                "#ember142"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "violations__img-without-alt",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<img src=\"assets/img/empire-state-building-moonlight.png\" id=\"violations__img-without-alt\" class=\"u-fill c-img ember-view\">",
+              "target": [
+                "#violations__img-without-alt"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "duplicate-id",
+                  "data": "ember145",
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Document has no static elements that share the same id attribute"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<li id=\"ember145\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+              "target": [
+                "#ember145"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "empty-heading",
+          "impact": null,
+          "tags": [
+            "cat.name-role-value",
+            "best-practice"
+          ],
+          "description": "Ensures headings have discernible text",
+          "help": "Headings must not be empty",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/empty-heading?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "has-visible-text",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element has text that is visible to screen readers"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h1 class=\"u-align-center\">Ember A11y Testing</h1>",
+              "target": [
+                ".application__header > h1"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "has-visible-text",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element has text that is visible to screen readers"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h2 data-test-selector=\"violations-page__passing-component\" id=\"ember130\" class=\"ember-view\">Violations\n</h2>",
+              "target": [
+                "#ember130"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "has-visible-text",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element has text that is visible to screen readers"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Button without title</h3>",
+              "target": [
+                "#ember131 > .c-violations-grid-item__header > h3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "has-visible-text",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element has text that is visible to screen readers"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Input without label</h3>",
+              "target": [
+                "#ember134 > .c-violations-grid-item__header > h3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "has-visible-text",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element has text that is visible to screen readers"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Poorly Contrasting Text Color</h3>",
+              "target": [
+                "#ember138 > .c-violations-grid-item__header > h3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "has-visible-text",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element has text that is visible to screen readers"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Non-standard HTML elements</h3>",
+              "target": [
+                "#ember141 > .c-violations-grid-item__header > h3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "has-visible-text",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element has text that is visible to screen readers"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">&lt;img&gt; Tags without `alt` attributes</h3>",
+              "target": [
+                "#ember142 > .c-violations-grid-item__header > h3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "has-visible-text",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element has text that is visible to screen readers"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Ungrouped radio inputs with a shared name</h3>",
+              "target": [
+                "#ember145 > .c-violations-grid-item__header > h3"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "form-field-multiple-labels",
+          "impact": null,
+          "tags": [
+            "cat.forms",
+            "wcag2a",
+            "wcag332"
+          ],
+          "description": "Ensures form field does not have multiple label elements",
+          "help": "Form field should not have multiple label elements",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/form-field-multiple-labels?application=axeAPI",
+          "nodes": [
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "multiple-label",
+                  "data": null,
+                  "relatedNodes": [
+                    {
+                      "html": "<label for=\"noise-level-0\" class=\"c-radio-track__radio-item\">",
+                      "target": [
+                        "label[for=\"noise-level-0\"]"
+                      ]
+                    }
+                  ],
+                  "impact": "moderate",
+                  "message": "Form field does not have multiple label elements"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+              "target": [
+                "#noise-level-0"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "multiple-label",
+                  "data": null,
+                  "relatedNodes": [
+                    {
+                      "html": "<label for=\"noise-level-1\" class=\"c-radio-track__radio-item\">",
+                      "target": [
+                        "label[for=\"noise-level-1\"]"
+                      ]
+                    }
+                  ],
+                  "impact": "moderate",
+                  "message": "Form field does not have multiple label elements"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+              "target": [
+                "#noise-level-1"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "multiple-label",
+                  "data": null,
+                  "relatedNodes": [
+                    {
+                      "html": "<label for=\"noise-level-2\" class=\"c-radio-track__radio-item\">",
+                      "target": [
+                        "label[for=\"noise-level-2\"]"
+                      ]
+                    }
+                  ],
+                  "impact": "moderate",
+                  "message": "Form field does not have multiple label elements"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+              "target": [
+                "#noise-level-2"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "multiple-label",
+                  "data": null,
+                  "relatedNodes": [
+                    {
+                      "html": "<label for=\"noise-level-3\" class=\"c-radio-track__radio-item\">",
+                      "target": [
+                        "label[for=\"noise-level-3\"]"
+                      ]
+                    }
+                  ],
+                  "impact": "moderate",
+                  "message": "Form field does not have multiple label elements"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+              "target": [
+                "#noise-level-3"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "multiple-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Form field does not have multiple label elements"
+                }
+              ],
+              "impact": null,
+              "html": "<input class=\"c-text-input__input\" id=\"violations__labeless-input\" type=\"text\">",
+              "target": [
+                "#violations__labeless-input"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "multiple-label",
+                  "data": null,
+                  "relatedNodes": [
+                    {
+                      "html": "<label class=\"u-fill-width u-align-center p-violations__grid-item-content--radio\" for=\"violations__radio-group-items--strawberries\">",
+                      "target": [
+                        ".p-violations__grid-item-content--radio.u-fill-width.u-align-center:nth-child(1)"
+                      ]
+                    }
+                  ],
+                  "impact": "moderate",
+                  "message": "Form field does not have multiple label elements"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+              "target": [
+                "#violations__radio-group-items--strawberries"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "multiple-label",
+                  "data": null,
+                  "relatedNodes": [
+                    {
+                      "html": "<label class=\"u-fill-width u-align-center p-violations__grid-item-content--radio\" for=\"violations__radio-group-items--blueberries\">",
+                      "target": [
+                        ".p-violations__grid-item-content--radio.u-fill-width.u-align-center:nth-child(2)"
+                      ]
+                    }
+                  ],
+                  "impact": "moderate",
+                  "message": "Form field does not have multiple label elements"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+              "target": [
+                "#violations__radio-group-items--blueberries"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "multiple-label",
+                  "data": null,
+                  "relatedNodes": [
+                    {
+                      "html": "<label class=\"u-fill-width u-align-center p-violations__grid-item-content--radio\" for=\"violations__radio-group-items--raspberries\">",
+                      "target": [
+                        ".p-violations__grid-item-content--radio.u-fill-width.u-align-center:nth-child(3)"
+                      ]
+                    }
+                  ],
+                  "impact": "moderate",
+                  "message": "Form field does not have multiple label elements"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+              "target": [
+                "#violations__radio-group-items--raspberries"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "heading-order",
+          "impact": null,
+          "tags": [
+            "cat.semantics",
+            "best-practice"
+          ],
+          "description": "Ensures the order of headings is semantically correct",
+          "help": "Heading levels should only increase by one",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/heading-order?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "heading-order",
+                  "data": 1,
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Heading order valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h1 class=\"u-align-center\">Ember A11y Testing</h1>",
+              "target": [
+                ".application__header > h1"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "heading-order",
+                  "data": 2,
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Heading order valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h2 data-test-selector=\"violations-page__passing-component\" id=\"ember130\" class=\"ember-view\">Violations\n</h2>",
+              "target": [
+                "#ember130"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "heading-order",
+                  "data": 3,
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Heading order valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Button without title</h3>",
+              "target": [
+                "#ember131 > .c-violations-grid-item__header > h3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "heading-order",
+                  "data": 3,
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Heading order valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Input without label</h3>",
+              "target": [
+                "#ember134 > .c-violations-grid-item__header > h3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "heading-order",
+                  "data": 3,
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Heading order valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Poorly Contrasting Text Color</h3>",
+              "target": [
+                "#ember138 > .c-violations-grid-item__header > h3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "heading-order",
+                  "data": 3,
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Heading order valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Non-standard HTML elements</h3>",
+              "target": [
+                "#ember141 > .c-violations-grid-item__header > h3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "heading-order",
+                  "data": 3,
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Heading order valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">&lt;img&gt; Tags without `alt` attributes</h3>",
+              "target": [
+                "#ember142 > .c-violations-grid-item__header > h3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "heading-order",
+                  "data": 3,
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Heading order valid"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<h3 class=\"c-violations-grid-item__title u-align-center\">Ungrouped radio inputs with a shared name</h3>",
+              "target": [
+                "#ember145 > .c-violations-grid-item__header > h3"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "identical-links-same-purpose",
+          "impact": null,
+          "tags": [
+            "wcag2aaa",
+            "wcag249",
+            "best-practice"
+          ],
+          "description": "Ensure that links with the same accessible name serve a similar purpose",
+          "help": "Links with the same name have a similar purpose",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/identical-links-same-purpose?application=axeAPI",
+          "nodes": [
+            {
+              "any": [],
+              "all": [
+                {
+                  "id": "identical-links-same-purpose",
+                  "data": {
+                    "name": "ember a11ys bestpractices demo app",
+                    "urlProps": {
+                      "protocol": "http:",
+                      "hostname": "ember-a11y.github.io",
+                      "port": "",
+                      "pathname": "/a11y-demo-app/",
+                      "search": {},
+                      "hash": "",
+                      "filename": ""
+                    }
+                  },
+                  "relatedNodes": [
+                    {
+                      "html": "<a href=\"https://ember-a11y.github.io/a11y-demo-app/\">Ember A11y's best-practices demo app</a>",
+                      "target": [
+                        "footer > a"
+                      ]
+                    }
+                  ],
+                  "impact": "minor",
+                  "message": "There are no other links with the same name, that go to a different URL"
+                }
+              ],
+              "none": [],
+              "impact": null,
+              "html": "<a href=\"https://ember-a11y.github.io/a11y-demo-app/\">Ember A11y's best-practices demo app</a>",
+              "target": [
+                "footer > a"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "image-redundant-alt",
+          "impact": null,
+          "tags": [
+            "cat.text-alternatives",
+            "best-practice"
+          ],
+          "description": "Ensure image alternative is not repeated as text",
+          "help": "Alternative text of images should not be repeated as text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/image-redundant-alt?application=axeAPI",
+          "nodes": [
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "duplicate-img-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element does not duplicate existing text in <img> alt text"
+                }
+              ],
+              "impact": null,
+              "html": "<img src=\"assets/img/empire-state-building-moonlight.png\" id=\"violations__img-without-alt\" class=\"u-fill c-img ember-view\">",
+              "target": [
+                "#violations__img-without-alt"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "label-title-only",
+          "impact": null,
+          "tags": [
+            "cat.forms",
+            "best-practice"
+          ],
+          "description": "Ensures that every form element is not solely labeled using the title or aria-describedby attributes",
+          "help": "Form elements should have a visible label",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/label-title-only?application=axeAPI",
+          "nodes": [
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "title-only",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Form element does not solely use title attribute for its label"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+              "target": [
+                "#noise-level-0"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "title-only",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Form element does not solely use title attribute for its label"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+              "target": [
+                "#noise-level-1"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "title-only",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Form element does not solely use title attribute for its label"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+              "target": [
+                "#noise-level-2"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "title-only",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Form element does not solely use title attribute for its label"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+              "target": [
+                "#noise-level-3"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "title-only",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Form element does not solely use title attribute for its label"
+                }
+              ],
+              "impact": null,
+              "html": "<input class=\"c-text-input__input\" id=\"violations__labeless-input\" type=\"text\">",
+              "target": [
+                "#violations__labeless-input"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "title-only",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Form element does not solely use title attribute for its label"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+              "target": [
+                "#violations__radio-group-items--strawberries"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "title-only",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Form element does not solely use title attribute for its label"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+              "target": [
+                "#violations__radio-group-items--blueberries"
+              ]
+            },
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "title-only",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Form element does not solely use title attribute for its label"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+              "target": [
+                "#violations__radio-group-items--raspberries"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "label",
+          "impact": "critical",
+          "tags": [
+            "cat.forms",
+            "wcag2a",
+            "wcag412",
+            "wcag131",
+            "section508",
+            "section508.22.n"
+          ],
+          "description": "Ensures every form element has a label",
+          "help": "Form elements must have labels",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/label?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "implicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an implicit (wrapped) <label>"
+                },
+                {
+                  "id": "explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an explicit <label>"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "hidden-explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has a visible explicit <label>"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-0\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"0\">",
+              "target": [
+                "#noise-level-0"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "implicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an implicit (wrapped) <label>"
+                },
+                {
+                  "id": "explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an explicit <label>"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "hidden-explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has a visible explicit <label>"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"true\" name=\"noise-level\" id=\"noise-level-1\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"1\">",
+              "target": [
+                "#noise-level-1"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "implicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an implicit (wrapped) <label>"
+                },
+                {
+                  "id": "explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an explicit <label>"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "hidden-explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has a visible explicit <label>"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-2\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"2\">",
+              "target": [
+                "#noise-level-2"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "implicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an implicit (wrapped) <label>"
+                },
+                {
+                  "id": "explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an explicit <label>"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "hidden-explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has a visible explicit <label>"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"noise-level\" id=\"noise-level-3\" class=\"c-radio-track__item-input ember-view\" type=\"radio\" value=\"3\">",
+              "target": [
+                "#noise-level-3"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "implicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an implicit (wrapped) <label>"
+                },
+                {
+                  "id": "explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an explicit <label>"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "hidden-explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has a visible explicit <label>"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--strawberries\" class=\"ember-view\" type=\"radio\" value=\"Strawberries\">",
+              "target": [
+                "#violations__radio-group-items--strawberries"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "implicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an implicit (wrapped) <label>"
+                },
+                {
+                  "id": "explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an explicit <label>"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "hidden-explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has a visible explicit <label>"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--blueberries\" class=\"ember-view\" type=\"radio\" value=\"Blueberries\">",
+              "target": [
+                "#violations__radio-group-items--blueberries"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "implicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an implicit (wrapped) <label>"
+                },
+                {
+                  "id": "explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has an explicit <label>"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "hidden-explicit-label",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "critical",
+                  "message": "Form element has a visible explicit <label>"
+                }
+              ],
+              "impact": null,
+              "html": "<input aria-checked=\"false\" name=\"fruits\" id=\"violations__radio-group-items--raspberries\" class=\"ember-view\" type=\"radio\" value=\"Raspberries\">",
+              "target": [
+                "#violations__radio-group-items--raspberries"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "landmark-banner-is-top-level",
+          "impact": null,
+          "tags": [
+            "cat.semantics",
+            "best-practice"
+          ],
+          "description": "Ensures the banner landmark is at top level",
+          "help": "Banner landmark must not be contained in another landmark",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-banner-is-top-level?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "landmark-is-top-level",
+                  "data": {
+                    "role": "banner"
+                  },
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "The banner landmark is at the top level."
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<header class=\"application__header\">\n    <h1 class=\"u-align-center\">Ember A11y Testing</h1>\n  </header>",
+              "target": [
+                ".application__header"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "landmark-main-is-top-level",
+          "impact": null,
+          "tags": [
+            "cat.semantics",
+            "best-practice"
+          ],
+          "description": "Ensures the main landmark is at top level",
+          "help": "Main landmark must not be contained in another landmark",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-main-is-top-level?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "landmark-is-top-level",
+                  "data": {
+                    "role": "main"
+                  },
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "The main landmark is at the top level."
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<main class=\"application__main-content u-relative u-fill-width o-content-box--lg\">",
+              "target": [
+                "main"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "landmark-no-duplicate-banner",
+          "impact": null,
+          "tags": [
+            "cat.semantics",
+            "best-practice"
+          ],
+          "description": "Ensures the document has at most one banner landmark",
+          "help": "Document must not have more than one banner landmark",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-no-duplicate-banner?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "page-no-duplicate-banner",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Document does not have more than one banner landmark"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<header class=\"application__header\">\n    <h1 class=\"u-align-center\">Ember A11y Testing</h1>\n  </header>",
+              "target": [
+                ".application__header"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "landmark-no-duplicate-contentinfo",
+          "impact": null,
+          "tags": [
+            "cat.semantics",
+            "best-practice"
+          ],
+          "description": "Ensures the document has at most one contentinfo landmark",
+          "help": "Document must not have more than one contentinfo landmark",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-no-duplicate-contentinfo?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "page-no-duplicate-contentinfo",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Document does not have more than one contentinfo landmark"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<footer class=\"p-violations__footer\">\n  For more on <strong>accessible</strong> user interface patterns, check out\n    <a href=\"https://ember-a11y.github.io/a11y-demo-app/\">Ember A11y's best-practices demo app</a>.\n</footer>",
+              "target": [
+                "footer"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "landmark-no-duplicate-main",
+          "impact": null,
+          "tags": [
+            "cat.semantics",
+            "best-practice"
+          ],
+          "description": "Ensures the document has at most one main landmark",
+          "help": "Document must not have more than one main landmark",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-no-duplicate-main?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "page-no-duplicate-main",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Document does not have more than one main landmark"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<main class=\"application__main-content u-relative u-fill-width o-content-box--lg\">",
+              "target": [
+                "main"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "landmark-unique",
+          "impact": null,
+          "tags": [
+            "cat.semantics",
+            "best-practice"
+          ],
+          "help": "Ensures landmarks are unique",
+          "description": "Landmarks must have a unique role or role/label/title (i.e. accessible name) combination",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-unique?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "landmark-is-unique",
+                  "data": {
+                    "role": "banner",
+                    "accessibleText": null
+                  },
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Landmarks must have a unique role or role/label/title (i.e. accessible name) combination"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<header class=\"application__header\">\n    <h1 class=\"u-align-center\">Ember A11y Testing</h1>\n  </header>",
+              "target": [
+                ".application__header"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "landmark-is-unique",
+                  "data": {
+                    "role": "main",
+                    "accessibleText": null
+                  },
+                  "relatedNodes": [],
+                  "impact": "moderate",
+                  "message": "Landmarks must have a unique role or role/label/title (i.e. accessible name) combination"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<main class=\"application__main-content u-relative u-fill-width o-content-box--lg\">",
+              "target": [
+                "main"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "link-name",
+          "impact": null,
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "wcag244",
+            "section508",
+            "section508.22.a"
+          ],
+          "description": "Ensures links have discernible text",
+          "help": "Links must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/link-name?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "has-visible-text",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "minor",
+                  "message": "Element has text that is visible to screen readers"
+                }
+              ],
+              "all": [],
+              "none": [
+                {
+                  "id": "focusable-no-name",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "Element is not in tab order or has accessible text"
+                }
+              ],
+              "impact": null,
+              "html": "<a href=\"https://ember-a11y.github.io/a11y-demo-app/\">Ember A11y's best-practices demo app</a>",
+              "target": [
+                "footer > a"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "list",
+          "impact": null,
+          "tags": [
+            "cat.structure",
+            "wcag2a",
+            "wcag131"
+          ],
+          "description": "Ensures that lists are structured correctly",
+          "help": "<ul> and <ol> must only directly contain <li>, <script> or <template> elements",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/list?application=axeAPI",
+          "nodes": [
+            {
+              "any": [],
+              "all": [],
+              "none": [
+                {
+                  "id": "only-listitems",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "List element only has direct children that are allowed inside <li> elements"
+                }
+              ],
+              "impact": null,
+              "html": "<ul class=\"p-violations__grid u-fill-width u-relative\">",
+              "target": [
+                ".p-violations__grid"
+              ]
+            }
+          ]
+        },
+        {
+          "id": "listitem",
+          "impact": null,
+          "tags": [
+            "cat.structure",
+            "wcag2a",
+            "wcag131"
+          ],
+          "description": "Ensures <li> elements are used semantically",
+          "help": "<li> elements must be contained in a <ul> or <ol>",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/listitem?application=axeAPI",
+          "nodes": [
+            {
+              "any": [
+                {
+                  "id": "listitem",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "List item has a <ul>, <ol> or role=\"list\" parent element"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<li id=\"ember131\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+              "target": [
+                "#ember131"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "listitem",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "List item has a <ul>, <ol> or role=\"list\" parent element"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<li id=\"ember134\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+              "target": [
+                "#ember134"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "listitem",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "List item has a <ul>, <ol> or role=\"list\" parent element"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<li id=\"ember138\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+              "target": [
+                "#ember138"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "listitem",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "List item has a <ul>, <ol> or role=\"list\" parent element"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<li id=\"ember141\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+              "target": [
+                "#ember141"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "listitem",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "List item has a <ul>, <ol> or role=\"list\" parent element"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<li id=\"ember142\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+              "target": [
+                "#ember142"
+              ]
+            },
+            {
+              "any": [
+                {
+                  "id": "listitem",
+                  "data": null,
+                  "relatedNodes": [],
+                  "impact": "serious",
+                  "message": "List item has a <ul>, <ol> or role=\"list\" parent element"
+                }
+              ],
+              "all": [],
+              "none": [],
+              "impact": null,
+              "html": "<li id=\"ember145\" class=\"p-violations__grid-item c-violations-grid-item o-content-box ember-view\">",
+              "target": [
+                "#ember145"
+              ]
+            }
+          ]
+        }
+      ],
+      "incomplete": [],
+      "inapplicable": [
+        {
+          "id": "accesskeys",
+          "impact": null,
+          "tags": [
+            "best-practice",
+            "cat.keyboard"
+          ],
+          "description": "Ensures every accesskey attribute value is unique",
+          "help": "accesskey attribute value must be unique",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/accesskeys?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "area-alt",
+          "impact": null,
+          "tags": [
+            "cat.text-alternatives",
+            "wcag2a",
+            "wcag111",
+            "wcag244",
+            "wcag412",
+            "section508",
+            "section508.22.a"
+          ],
+          "description": "Ensures <area> elements of image maps have alternate text",
+          "help": "Active <area> elements must have alternate text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/area-alt?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "aria-allowed-role",
+          "impact": null,
+          "tags": [
+            "cat.aria",
+            "best-practice"
+          ],
+          "description": "Ensures role attribute has an appropriate value for the element",
+          "help": "ARIA role must be appropriate for the element",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-allowed-role?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "aria-hidden-body",
+          "impact": null,
+          "tags": [
+            "cat.aria",
+            "wcag2a",
+            "wcag412"
+          ],
+          "description": "Ensures aria-hidden='true' is not present on the document body.",
+          "help": "aria-hidden='true' must not be present on the document body",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-hidden-body?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "aria-hidden-focus",
+          "impact": null,
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "wcag131"
+          ],
+          "description": "Ensures aria-hidden elements do not contain focusable elements",
+          "help": "ARIA hidden element must not contain focusable elements",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-hidden-focus?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "aria-input-field-name",
+          "impact": null,
+          "tags": [
+            "wcag2a",
+            "wcag412"
+          ],
+          "description": "Ensures every ARIA input field has an accessible name",
+          "help": "ARIA input fields must have an accessible name",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-input-field-name?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "aria-required-attr",
+          "impact": null,
+          "tags": [
+            "cat.aria",
+            "wcag2a",
+            "wcag412"
+          ],
+          "description": "Ensures elements with ARIA roles have all required ARIA attributes",
+          "help": "Required ARIA attributes must be provided",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-required-attr?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "aria-required-children",
+          "impact": null,
+          "tags": [
+            "cat.aria",
+            "wcag2a",
+            "wcag131"
+          ],
+          "description": "Ensures elements with an ARIA role that require child roles contain them",
+          "help": "Certain ARIA roles must contain particular children",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-required-children?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "aria-required-parent",
+          "impact": null,
+          "tags": [
+            "cat.aria",
+            "wcag2a",
+            "wcag131"
+          ],
+          "description": "Ensures elements with an ARIA role that require parent roles are contained by them",
+          "help": "Certain ARIA roles must be contained by particular parents",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-required-parent?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "aria-roledescription",
+          "impact": null,
+          "tags": [
+            "cat.aria",
+            "wcag2a",
+            "wcag412"
+          ],
+          "description": "Ensure aria-roledescription is only used on elements with an implicit or explicit role",
+          "help": "Use aria-roledescription on elements with a semantic role",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-roledescription?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "aria-roles",
+          "impact": null,
+          "tags": [
+            "cat.aria",
+            "wcag2a",
+            "wcag412"
+          ],
+          "description": "Ensures all elements with a role attribute use a valid value",
+          "help": "ARIA roles used must conform to valid values",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-roles?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "aria-toggle-field-name",
+          "impact": null,
+          "tags": [
+            "wcag2a",
+            "wcag412"
+          ],
+          "description": "Ensures every ARIA toggle field has an accessible name",
+          "help": "ARIA toggle fields have an accessible name",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/aria-toggle-field-name?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "autocomplete-valid",
+          "impact": null,
+          "tags": [
+            "cat.forms",
+            "wcag21aa",
+            "wcag135"
+          ],
+          "description": "Ensure the autocomplete attribute is correct and suitable for the form field",
+          "help": "autocomplete attribute must be used correctly",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/autocomplete-valid?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "definition-list",
+          "impact": null,
+          "tags": [
+            "cat.structure",
+            "wcag2a",
+            "wcag131"
+          ],
+          "description": "Ensures <dl> elements are structured correctly",
+          "help": "<dl> elements must only directly contain properly-ordered <dt> and <dd> groups, <script>, <template> or <div> elements",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/definition-list?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "dlitem",
+          "impact": null,
+          "tags": [
+            "cat.structure",
+            "wcag2a",
+            "wcag131"
+          ],
+          "description": "Ensures <dt> and <dd> elements are contained by a <dl>",
+          "help": "<dt> and <dd> elements must be contained by a <dl>",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/dlitem?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "document-title",
+          "impact": null,
+          "tags": [
+            "cat.text-alternatives",
+            "wcag2a",
+            "wcag242",
+            "ACT"
+          ],
+          "description": "Ensures each HTML document contains a non-empty <title> element",
+          "help": "Documents must have <title> element to aid in navigation",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/document-title?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "frame-tested",
+          "impact": null,
+          "tags": [
+            "cat.structure",
+            "review-item",
+            "best-practice"
+          ],
+          "description": "Ensures <iframe> and <frame> elements contain the axe-core script",
+          "help": "Frames must be tested with axe-core",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/frame-tested?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "frame-title-unique",
+          "impact": null,
+          "tags": [
+            "cat.text-alternatives",
+            "best-practice"
+          ],
+          "description": "Ensures <iframe> and <frame> elements contain a unique title attribute",
+          "help": "Frames must have a unique title attribute",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/frame-title-unique?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "frame-title",
+          "impact": null,
+          "tags": [
+            "cat.text-alternatives",
+            "wcag2a",
+            "wcag241",
+            "wcag412",
+            "section508",
+            "section508.22.i"
+          ],
+          "description": "Ensures <iframe> and <frame> elements contain a non-empty title attribute",
+          "help": "Frames must have title attribute",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/frame-title?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "html-has-lang",
+          "impact": null,
+          "tags": [
+            "cat.language",
+            "wcag2a",
+            "wcag311",
+            "ACT"
+          ],
+          "description": "Ensures every HTML document has a lang attribute",
+          "help": "<html> element must have a lang attribute",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/html-has-lang?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "html-lang-valid",
+          "impact": null,
+          "tags": [
+            "cat.language",
+            "wcag2a",
+            "wcag311",
+            "ACT"
+          ],
+          "description": "Ensures the lang attribute of the <html> element has a valid value",
+          "help": "<html> element must have a valid value for the lang attribute",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/html-lang-valid?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "html-xml-lang-mismatch",
+          "impact": null,
+          "tags": [
+            "cat.language",
+            "wcag2a",
+            "wcag311",
+            "ACT"
+          ],
+          "description": "Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page",
+          "help": "HTML elements with lang and xml:lang must have the same base language",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/html-xml-lang-mismatch?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "input-button-name",
+          "impact": null,
+          "tags": [
+            "cat.name-role-value",
+            "wcag2a",
+            "wcag412",
+            "section508",
+            "section508.22.a"
+          ],
+          "description": "Ensures input buttons have discernible text",
+          "help": "Input buttons must have discernible text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/input-button-name?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "input-image-alt",
+          "impact": null,
+          "tags": [
+            "cat.text-alternatives",
+            "wcag2a",
+            "wcag111",
+            "section508",
+            "section508.22.a",
+            "ACT"
+          ],
+          "description": "Ensures <input type=\"image\"> elements have alternate text",
+          "help": "Image buttons must have alternate text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/input-image-alt?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "landmark-complementary-is-top-level",
+          "impact": null,
+          "tags": [
+            "cat.semantics",
+            "best-practice"
+          ],
+          "description": "Ensures the complementary landmark or aside is at top level",
+          "help": "Aside must not be contained in another landmark",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-complementary-is-top-level?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "landmark-contentinfo-is-top-level",
+          "impact": null,
+          "tags": [
+            "cat.semantics",
+            "best-practice"
+          ],
+          "description": "Ensures the contentinfo landmark is at top level",
+          "help": "Contentinfo landmark must not be contained in another landmark",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-contentinfo-is-top-level?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "landmark-one-main",
+          "impact": null,
+          "tags": [
+            "cat.semantics",
+            "best-practice"
+          ],
+          "description": "Ensures the document has a main landmark",
+          "help": "Document must have one main landmark",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/landmark-one-main?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "marquee",
+          "impact": null,
+          "tags": [
+            "cat.parsing",
+            "wcag2a",
+            "wcag222"
+          ],
+          "description": "Ensures <marquee> elements are not used",
+          "help": "<marquee> elements are deprecated and must not be used",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/marquee?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "meta-refresh",
+          "impact": null,
+          "tags": [
+            "cat.time-and-media",
+            "wcag2a",
+            "wcag2aaa",
+            "wcag221",
+            "wcag224",
+            "wcag325"
+          ],
+          "description": "Ensures <meta http-equiv=\"refresh\"> is not used",
+          "help": "Timed refresh must not exist",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/meta-refresh?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "meta-viewport-large",
+          "impact": null,
+          "tags": [
+            "cat.sensory-and-visual-cues",
+            "best-practice"
+          ],
+          "description": "Ensures <meta name=\"viewport\"> can scale a significant amount",
+          "help": "Users should be able to zoom and scale the text up to 500%",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/meta-viewport-large?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "meta-viewport",
+          "impact": null,
+          "tags": [
+            "cat.sensory-and-visual-cues",
+            "best-practice"
+          ],
+          "description": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming",
+          "help": "Zooming and scaling must not be disabled",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/meta-viewport?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "object-alt",
+          "impact": null,
+          "tags": [
+            "cat.text-alternatives",
+            "wcag2a",
+            "wcag111",
+            "section508",
+            "section508.22.a"
+          ],
+          "description": "Ensures <object> elements have alternate text",
+          "help": "<object> elements must have alternate text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/object-alt?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "page-has-heading-one",
+          "impact": null,
+          "tags": [
+            "cat.semantics",
+            "best-practice"
+          ],
+          "description": "Ensure that the page, or at least one of its frames contains a level-one heading",
+          "help": "Page must contain a level-one heading",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/page-has-heading-one?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "region",
+          "impact": null,
+          "tags": [
+            "cat.keyboard",
+            "best-practice"
+          ],
+          "description": "Ensures all page content is contained by landmarks",
+          "help": "All page content must be contained by landmarks",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/region?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "role-img-alt",
+          "impact": null,
+          "tags": [
+            "cat.text-alternatives",
+            "wcag2a",
+            "wcag111",
+            "section508",
+            "section508.22.a"
+          ],
+          "description": "Ensures [role='img'] elements have alternate text",
+          "help": "[role='img'] elements have an alternative text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/role-img-alt?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "scope-attr-valid",
+          "impact": null,
+          "tags": [
+            "cat.tables",
+            "best-practice"
+          ],
+          "description": "Ensures the scope attribute is used correctly on tables",
+          "help": "scope attribute should be used correctly",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/scope-attr-valid?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "scrollable-region-focusable",
+          "impact": null,
+          "tags": [
+            "wcag2a",
+            "wcag211"
+          ],
+          "description": "Elements that have scrollable content should be accessible by keyboard",
+          "help": "Ensure that scrollable region has keyboard access",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/scrollable-region-focusable?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "server-side-image-map",
+          "impact": null,
+          "tags": [
+            "cat.text-alternatives",
+            "wcag2a",
+            "wcag211",
+            "section508",
+            "section508.22.f"
+          ],
+          "description": "Ensures that server-side image maps are not used",
+          "help": "Server-side image maps must not be used",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/server-side-image-map?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "skip-link",
+          "impact": null,
+          "tags": [
+            "cat.keyboard",
+            "best-practice"
+          ],
+          "description": "Ensure all skip links have a focusable target",
+          "help": "The skip-link target should exist and be focusable",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/skip-link?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "svg-img-alt",
+          "impact": null,
+          "tags": [
+            "cat.text-alternatives",
+            "wcag2a",
+            "wcag111",
+            "section508",
+            "section508.22.a"
+          ],
+          "description": "Ensures svg elements with an img, graphics-document or graphics-symbol role have an accessible text",
+          "help": "svg elements with an img role have an alternative text",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/svg-img-alt?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "tabindex",
+          "impact": null,
+          "tags": [
+            "cat.keyboard",
+            "best-practice"
+          ],
+          "description": "Ensures tabindex attribute values are not greater than 0",
+          "help": "Elements should not have tabindex greater than zero",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/tabindex?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "table-duplicate-name",
+          "impact": null,
+          "tags": [
+            "cat.tables",
+            "best-practice"
+          ],
+          "description": "Ensure that tables do not have the same summary and caption",
+          "help": "The <caption> element should not contain the same text as the summary attribute",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/table-duplicate-name?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "td-headers-attr",
+          "impact": null,
+          "tags": [
+            "cat.tables",
+            "wcag2a",
+            "wcag131",
+            "section508",
+            "section508.22.g"
+          ],
+          "description": "Ensure that each cell in a table using the headers refers to another cell in that table",
+          "help": "All cells in a table element that use the headers attribute must only refer to other cells of that same table",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/td-headers-attr?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "th-has-data-cells",
+          "impact": null,
+          "tags": [
+            "cat.tables",
+            "wcag2a",
+            "wcag131",
+            "section508",
+            "section508.22.g"
+          ],
+          "description": "Ensure that each table header in a data table refers to data cells",
+          "help": "All th elements and elements with role=columnheader/rowheader must have data cells they describe",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/th-has-data-cells?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "valid-lang",
+          "impact": null,
+          "tags": [
+            "cat.language",
+            "wcag2aa",
+            "wcag312"
+          ],
+          "description": "Ensures lang attributes have valid values",
+          "help": "lang attribute must have a valid value",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/valid-lang?application=axeAPI",
+          "nodes": []
+        },
+        {
+          "id": "video-caption",
+          "impact": null,
+          "tags": [
+            "cat.text-alternatives",
+            "wcag2a",
+            "wcag122",
+            "section508",
+            "section508.22.a"
+          ],
+          "description": "Ensures <video> elements have captions",
+          "help": "<video> elements must have captions",
+          "helpUrl": "https://dequeuniversity.com/rules/axe/4.0/video-caption?application=axeAPI",
+          "nodes": []
+        }
+      ]
+    }
+  }
+]

--- a/types/@ember/test-helpers.d.ts
+++ b/types/@ember/test-helpers.d.ts
@@ -1,5 +1,19 @@
 type Hook = (...args: any[]) => void | Promise<void>;
 
+interface BaseContext {
+  [key: string]: any;
+}
+
+interface ITestMetadata {
+  testName?: string;
+  setupTypes: string[];
+  usedHelpers: string[];
+  [key: string]: any;
+
+  readonly isRendering: boolean;
+  readonly isApplication: boolean;
+}
+
 declare module '@ember/test-helpers' {
   export type HookUnregister = {
     unregister: () => void;
@@ -16,4 +30,6 @@ declare module '@ember/test-helpers' {
     label: string,
     ...args: any[]
   ): Promise<void>;
+
+  export function getTestMetadata(context: BaseContext): ITestMetadata;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2750,7 +2750,7 @@ bluebird@^3.1.1, bluebird@^3.4.6:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-body-parser@1.19.0:
+body-parser@1.19.0, body-parser@^1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
@@ -4099,6 +4099,11 @@ dag-map@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/dag-map/-/dag-map-2.0.2.tgz#9714b472de82a1843de2fba9b6876938cab44c68"
   integrity sha1-lxS0ct6CoYQ94vuptodpOMq0TGg=
+
+date-and-time@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.14.1.tgz#969634697b78956fb66b8be6fb0f39fbd631f2f6"
+  integrity sha512-M4RggEH5OF2ZuCOxgOU67R6Z9ohjKbxGvAQz48vj53wLmL0bAgumkBvycR32f30pK+Og9pIR+RFDyChbaE4oLA==
 
 debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
Adds support for combining the custom reporter with custom middleware, which allows for serializing the results to JSON.

```js
// tests/test-helper.js
import { setupMiddlewareReporter } from 'ember-a11y-testing';
// ...

setupMiddlewareReporter();

// ...
```

This will setup a custom reporter, which gathers the test module name, test name, and violations for each failed audit. Once the suite is done, these results are posted to the testem middleware, ultimately serializing the results to disc.

TODO:
- [x] Add tests for `setupMiddlewareReporter`
- [x] Update `setupMiddleware` test to use real `AxeResults`
- [x] Determine which specific directory path to pass to `setupMiddlewareReporter` in order to save the results.