### PR TITLE
Adding enhanced console logging

### DIFF
--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -13,5 +13,6 @@ export {
   setupMiddlewareReporter,
 } from './setup-middleware-reporter';
 export { storeResults, printResults } from './logger';
+export { setupConsoleLogger } from './setup-console-logger';
 
 export { InvocationStrategy, A11yAuditReporter } from './types';

--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -12,5 +12,6 @@ export {
   middlewareReporter as _middlewareReporter,
   setupMiddlewareReporter,
 } from './setup-middleware-reporter';
+export { storeResults, printResults } from './logger';
 
 export { InvocationStrategy, A11yAuditReporter } from './types';

--- a/addon-test-support/logger.ts
+++ b/addon-test-support/logger.ts
@@ -1,7 +1,7 @@
 import axeCore, { AxeResults, NodeResult, RelatedNode, Result } from 'axe-core';
 
 /**
- * This file is heavily borrowed from https://github.com/dequelabs/react-axe
+ * This file is heavily borrowed from https://github.com/dequelabs/react-axe/blob/d3245b32fc5ed19e3c7b2c43d2815fe63f5875cb/index.ts
  *
  * An issue (https://github.com/dequelabs/react-axe/issues/180) has been opened which
  * suggests extracting out the common pieces of axe formatting to a separate repository,

--- a/addon-test-support/logger.ts
+++ b/addon-test-support/logger.ts
@@ -1,0 +1,186 @@
+import axeCore, { AxeResults, NodeResult, RelatedNode, Result } from 'axe-core';
+
+/**
+ * This file is heavily borrowed from https://github.com/dequelabs/react-axe
+ *
+ * An issue (https://github.com/dequelabs/react-axe/issues/180) has been opened which
+ * suggests extracting out the common pieces of axe formatting to a separate repository,
+ * which would allow a lot of these functions to be removed.
+ */
+
+// @reference axe-core https://github.com/dequelabs/axe-core/blob/develop/lib/core/base/audit.js
+type AxeCoreNodeResultKey = 'any' | 'all' | 'none';
+
+interface AxeWithAudit {
+  _audit: {
+    data: {
+      failureSummaries: {
+        any: {
+          failureMessage: (args: string[]) => string;
+        };
+        all: {
+          failureMessage: (args: string[]) => string;
+        };
+        none: {
+          failureMessage: (args: string[]) => string;
+        };
+      };
+    };
+  };
+}
+
+// contrasted against Chrome default color of #ffffff
+const lightTheme = {
+  serious: '#d93251',
+  minor: '#d24700',
+  text: 'black',
+};
+
+// contrasted against Safari dark mode color of #535353
+const darkTheme = {
+  serious: '#ffb3b3',
+  minor: '#ffd500',
+  text: 'white',
+};
+
+const theme =
+  window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? darkTheme
+    : lightTheme;
+
+const boldCourier = 'font-weight:bold;font-family:Courier;';
+const critical = `color:${theme.serious};font-weight:bold;`;
+const serious = `color:${theme.serious};font-weight:normal;`;
+const moderate = `color:${theme.minor};font-weight:bold;`;
+const minor = `color:${theme.minor};font-weight:normal;`;
+const defaultReset = `font-color:${theme.text};font-weight:normal;`;
+
+const testSuiteResults: Result[][] = [];
+const cache: { [key: string]: string } = {};
+
+function deduplicateViolations(results: AxeResults) {
+  return results.violations.filter((result) => {
+    result.nodes = result.nodes.filter((node) => {
+      const key: string = node.target.toString() + result.id;
+      const retVal = !cache[key];
+      cache[key] = key;
+      return retVal;
+    });
+    return !!result.nodes.length;
+  });
+}
+
+/**
+ * Log the axe result node to the console
+ * @param {NodeResult} node
+ * @param {Function} logFn console log function to use (error, warn, log, etc.)
+ */
+function logElement(
+  node: NodeResult | RelatedNode,
+  logFn: (...args: any[]) => void
+): void {
+  const el = document.querySelector(node.target.toString());
+  if (!el) {
+    logFn('Selector: %c%s', boldCourier, node.target.toString());
+  } else {
+    logFn('Element: %o', el);
+  }
+}
+
+/**
+ * Log the axe result node html tot he console
+ * @param {NodeResult} node
+ */
+function logHtml(node: NodeResult | RelatedNode): void {
+  console.log('HTML: %c%s', boldCourier, node.html);
+}
+
+/**
+ * Log the failure message of a node result.
+ * @param {NodeResult} node
+ * @param {String} key which check array to log from (any, all, none)
+ */
+function logFailureMessage(node: NodeResult, key: AxeCoreNodeResultKey): void {
+  // this exists on axe but we don't export it as part of the typescript
+  // namespace, so just let me use it as I need
+  const message: string = ((axeCore as unknown) as AxeWithAudit)._audit.data.failureSummaries[
+    key
+  ].failureMessage(node[key].map((check) => check.message || ''));
+
+  console.error(message);
+}
+
+/**
+ * Log as a group the node result and failure message.
+ * @param {NodeResult} node
+ * @param {String} key which check array to log from (any, all, none)
+ */
+function failureSummary(node: NodeResult, key: AxeCoreNodeResultKey): void {
+  if (node[key].length > 0) {
+    logElement(node, console.groupCollapsed);
+    logHtml(node);
+    logFailureMessage(node, key);
+
+    let relatedNodes: RelatedNode[] = [];
+    node[key].forEach((check) => {
+      relatedNodes = relatedNodes.concat(check.relatedNodes || []);
+    });
+
+    if (relatedNodes.length > 0) {
+      console.groupCollapsed('Related nodes');
+      relatedNodes.forEach((relatedNode) => {
+        logElement(relatedNode, console.log);
+        logHtml(relatedNode);
+      });
+      console.groupEnd();
+    }
+
+    console.groupEnd();
+  }
+}
+
+export function storeResults(results: AxeResults) {
+  if (results.violations.length > 0) {
+    testSuiteResults.push(deduplicateViolations(results));
+  }
+}
+
+export function printResults() {
+  console.group('%cAxe issues', serious);
+  testSuiteResults.forEach((results) => {
+    results.forEach((result) => {
+      let fmt: string;
+      switch (result.impact) {
+        case 'critical':
+          fmt = critical;
+          break;
+        case 'serious':
+          fmt = serious;
+          break;
+        case 'moderate':
+          fmt = moderate;
+          break;
+        case 'minor':
+          fmt = minor;
+          break;
+        default:
+          fmt = minor;
+          break;
+      }
+      console.groupCollapsed(
+        '%c%s: %c%s %s',
+        fmt,
+        result.impact,
+        defaultReset,
+        result.help,
+        result.helpUrl
+      );
+      result.nodes.forEach((node) => {
+        failureSummary(node, 'any');
+        failureSummary(node, 'none');
+      });
+      console.groupEnd();
+    });
+  });
+  console.groupEnd();
+}

--- a/addon-test-support/reporter.ts
+++ b/addon-test-support/reporter.ts
@@ -2,9 +2,12 @@ import QUnit from 'qunit';
 import { AxeResults } from 'axe-core';
 import formatViolation from './format-violation';
 import { A11yAuditReporter } from './types';
+import { storeResults } from './logger';
 
 const DEFAULT_REPORTER = async (results: AxeResults) => {
   let violations = results.violations;
+
+  storeResults(results);
 
   if (violations.length) {
     let allViolations = violations.map((violation) => {

--- a/addon-test-support/setup-console-logger.ts
+++ b/addon-test-support/setup-console-logger.ts
@@ -1,0 +1,8 @@
+import QUnit from 'qunit';
+import { printResults } from './logger';
+
+export function setupConsoleLogger() {
+  QUnit.done(function () {
+    printResults();
+  });
+}

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,14 +1,11 @@
-import QUnit from 'qunit';
 import Application from 'dummy/app';
 import config from 'dummy/config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
-import { printResults } from 'ember-a11y-testing/test-support';
+import { setupConsoleLogger } from 'ember-a11y-testing/test-support';
 
 setApplication(Application.create(config.APP));
 
-QUnit.done(function () {
-  printResults();
-});
+setupConsoleLogger();
 
 start();

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,8 +1,14 @@
+import QUnit from 'qunit';
 import Application from 'dummy/app';
 import config from 'dummy/config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import { printResults } from 'ember-a11y-testing/test-support';
 
 setApplication(Application.create(config.APP));
+
+QUnit.done(function () {
+  printResults();
+});
 
 start();


### PR DESCRIPTION
Recent refactors removed the feature that output failures to the console. This PR restores that, using a slightly nicer format inspired by https://github.com/dequelabs/react-axe. 

[An issue](https://github.com/dequelabs/react-axe/issues/180) has been opened on that repository which proposes extracting the formatting functionality to a separate repo, in order to reduce duplication.

Example:

<img width="638" alt="Screen Shot 2020-09-09 at 9 36 57 AM" src="https://user-images.githubusercontent.com/180990/92627346-12996580-f280-11ea-868b-0157f45784c5.png">

