### PR TITLE
Downgrading ember-cli-typescript to 3.0.0 for embroider compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "broccoli-merge-trees": "^4.2.0",
     "date-and-time": "^0.14.1",
     "ember-cli-babel": "^7.21.0",
-    "ember-cli-typescript": "^4.0.0",
+    "ember-cli-typescript": "^3.0.0",
     "ember-cli-version-checker": "^5.1.1",
     "ember-destroyable-polyfill": "^2.0.1",
     "fs-extra": "^9.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5462,7 +5462,7 @@ ember-cli-typescript@^2.0.2:
     stagehand "^1.0.0"
     walk-sync "^1.0.0"
 
-ember-cli-typescript@^3.1.3:
+ember-cli-typescript@^3.0.0, ember-cli-typescript@^3.1.3:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz#21d6ccd670d1f2e34c9cce68c6e32c442f46806b"
   integrity sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==
@@ -5481,22 +5481,6 @@ ember-cli-typescript@^3.1.3:
     semver "^6.3.0"
     stagehand "^1.0.0"
     walk-sync "^2.0.0"
-
-ember-cli-typescript@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-4.0.0.tgz#690f0cd3d15f4a69ae6d89f25b70b5997ae59161"
-  integrity sha512-ZwnBbBJ0yAIKq4FVgNFkxfMwqJhw6PyT45Enp2RvWIgzgaYCId8brrSgg3tvVWWjA7N5hiT4Ilyz5jrQwrnU1Q==
-  dependencies:
-    ansi-to-html "^0.6.6"
-    broccoli-stew "^3.0.0"
-    debug "^4.0.0"
-    execa "^4.0.0"
-    fs-extra "^9.0.1"
-    resolve "^1.5.0"
-    rsvp "^4.8.1"
-    semver "^7.3.2"
-    stagehand "^1.0.0"
-    walk-sync "^2.2.0"
 
 ember-cli-uglify@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Using `ember-cli-typescript@4.0.0` results in the typescript files not being correctly transpiled when using embroider. This PR downgrades the version to `3.0.0`. 

Issue: https://github.com/embroider-build/embroider/issues/528