### PR TITLE
Adding validate-peer-dependencies over version checker

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const Funnel = require('broccoli-funnel');
 const MergeTrees = require('broccoli-merge-trees');
-const VersionChecker = require('ember-cli-version-checker');
+const validatePeerDependencies = require('validate-peer-dependencies');
 const setupMiddleware = require('./setup-middleware');
 
 // The different types/area for which we have content for.
@@ -13,6 +13,14 @@ const ALLOWED_CONTENT_FOR = ['head-footer', 'test-head-footer'];
 module.exports = {
   name: require('./package').name,
 
+  init() {
+    this._super.init.apply(this, arguments);
+
+    validatePeerDependencies(__dirname, {
+      resolvePeerDependenciesFrom: this.parent.root,
+    });
+  },
+
   /**
    * Includes axe-core in builds that have tests. It includes the un-minified
    * version in case of a need to debug.
@@ -20,15 +28,6 @@ module.exports = {
    */
   included: function (app) {
     this._super.included.apply(this, arguments);
-
-    let checker = VersionChecker.forProject(this.project);
-    let check = checker.check({
-      '@ember/test-helpers': '>= 2.0.0-beta.6',
-    });
-
-    check.assert(
-      `[ember-a11y-testing] Missing required version of @ember/test-helpers`
-    );
 
     if (app.tests) {
       let type = { type: 'test' };

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "date-and-time": "^0.14.1",
     "ember-cli-babel": "^7.21.0",
     "ember-cli-typescript": "^3.0.0",
-    "ember-cli-version-checker": "^5.1.1",
     "ember-destroyable-polyfill": "^2.0.1",
-    "fs-extra": "^9.0.1"
+    "fs-extra": "^9.0.1",
+    "validate-peer-dependencies": "^1.1.0"
   },
   "devDependencies": {
     "@ember/jquery": "^1.1.0",
@@ -95,6 +95,9 @@
     "sass": "^1.26.10",
     "tmp": "^0.2.1",
     "typescript": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@ember/test-helpers": "^2.0.0"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,9 +1095,9 @@
     silent-error "^1.1.1"
 
 "@ember/test-helpers@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.0.0.tgz#a09b7656f3df378beb5e2f3cf5f63ba9a87a41cf"
-  integrity sha512-COBrlXawM4ncnuaqgOXAQGUsbzQcTlKRhCGzPUnyZMTHYTvV2Hs4+X5+llPQpwP6WCjDgBI/831rQwJDvJ/Z9g==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.0.1.tgz#cf52419b5eae95bbed3e9bf36927f871b8c03779"
+  integrity sha512-T1ch0w7JLd0hZOSUl8IROCYzCyGefDJzz1YzDEBTdHIwcXCRrQA1xCp6W4pYjHoOkZO35pxYWwgQRWEgpZsELg==
   dependencies:
     "@ember/test-waiters" "^2.2.0"
     broccoli-debug "^0.6.5"
@@ -1107,12 +1107,12 @@
     ember-destroyable-polyfill "^2.0.1"
 
 "@ember/test-waiters@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@ember/test-waiters/-/test-waiters-2.2.0.tgz#48539d7bae52f0f4f4ce0f438a23b50c6a84f48f"
-  integrity sha512-vMhJluP6+fV42f0HXi6RnVaS6Q1Ak0aCHvvioyburuCpYOKAiPvjDzkkiufxlzi/Oocie4azkXL8b3FHqeMe2Q==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@ember/test-waiters/-/test-waiters-2.3.0.tgz#0da40153092ca064007888e63f6f5819efd38a63"
+  integrity sha512-cezrBqy1BbQbjm09EqU/mXJOdWRP4zdhPBAnpW1myAsmscAM0QQDMauNrZLWcrND0a0WfottxS+rvvddhWtfdQ==
   dependencies:
     ember-cli-babel "^7.21.0"
-    ember-cli-typescript "^3.1.3"
+    ember-cli-typescript "^3.1.4"
     ember-cli-version-checker "^5.1.1"
     semver "^7.1.3"
 
@@ -5424,7 +5424,7 @@ ember-cli-typescript@^2.0.2:
     stagehand "^1.0.0"
     walk-sync "^1.0.0"
 
-ember-cli-typescript@^3.0.0, ember-cli-typescript@^3.1.3:
+ember-cli-typescript@^3.0.0, ember-cli-typescript@^3.1.4:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-3.1.4.tgz#21d6ccd670d1f2e34c9cce68c6e32c442f46806b"
   integrity sha512-HJ73kL45OGRmIkPhBNFt31I1SGUvdZND+LCH21+qpq3pPlFpJG8GORyXpP+2ze8PbnITNLzwe5AwUrpyuRswdQ==
@@ -12531,7 +12531,7 @@ validate-npm-package-name@^3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-validate-peer-dependencies@^1.0.0:
+validate-peer-dependencies@^1.0.0, validate-peer-dependencies@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/validate-peer-dependencies/-/validate-peer-dependencies-1.1.0.tgz#8240a115df121ea35b0bb082255b38b5c591d7e1"
   integrity sha512-eHHxI3fNMqu8bzWPRWWgV72kBJkWwRCeEua7yC7UI6dsqC55orhxKAC3uyQfCjjToOyAZ8mpNrbQH+NMoYBn1w==


### PR DESCRIPTION
Uses new `validate-peer-dependencies` package over `ember-cli-version-checker`.