### PR TITLE
Fix cannot find module `qunit` under embroider

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -16,17 +16,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 10.x
-      - name: install dependencies
-        run: yarn install --frozen-lockfile --non-interactive
-      - name: lint
-        run: yarn lint
-      - name: test
-        run: yarn test:ember
-      - name: test node
-        run: yarn test:node
+      - uses: volta-cli/action@v1
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+      - run: yarn test:ember
+      - run: yarn test:node
 
   floating-dependencies:
     name: Floating dependencies
@@ -34,13 +28,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 10.x
-      - name: install dependencies
-        run: yarn install --no-lockfile --non-interactive
-      - name: test
-        run: yarn test:ember-compatibility
+      - uses: volta-cli/action@v1
+      - run: yarn install --no-lockfile
+      - run: yarn test:ember-compatibility
 
   try-scenarios:
     name: ${{ matrix.ember-try-scenario }}
@@ -67,10 +57,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 10.x
-      - name: install dependencies
-        run: yarn install
-      - name: test
-        run: node_modules/.bin/ember try:one ${{ matrix.ember-try-scenario }}
+      - uses: volta-cli/action@v1
+      - run: yarn install --frozen-lockfile
+      - run: node_modules/.bin/ember try:one ${{ matrix.ember-try-scenario }}
+

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -30,7 +30,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
       - run: yarn install --no-lockfile
-      - run: yarn test:ember-compatibility
+      - run: yarn test:ember
+      - run: yarn test:node
 
   try-scenarios:
     name: ${{ matrix.ember-try-scenario }}
@@ -59,4 +60,3 @@ jobs:
       - uses: volta-cli/action@v1
       - run: yarn install --frozen-lockfile
       - run: node_modules/.bin/ember try:one ${{ matrix.ember-try-scenario }}
-

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -34,9 +34,8 @@ jobs:
 
   try-scenarios:
     name: ${{ matrix.ember-try-scenario }}
-
+    timeout-minutes: 15
     runs-on: ubuntu-latest
-
     needs: test
 
     strategy:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -62,6 +62,8 @@ jobs:
           - ember-canary
           - ember-default-with-jquery
           - ember-classic
+          - embroider-safe
+          - embroider-optimized
 
     steps:
       - uses: actions/checkout@v2

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
+const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
   return {
@@ -110,6 +111,8 @@ module.exports = async function () {
           },
         },
       },
+      embroiderSafe(),
+      embroiderOptimized(),
     ],
   };
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,7 +6,6 @@ module.exports = function (defaults) {
   const self = defaults.project.findAddonByName('ember-a11y-testing');
   const autoImport = self.options.autoImport;
   let app = new EmberAddon(defaults, {
-    // Add options here
     autoImport,
   });
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -16,23 +16,6 @@ module.exports = function (defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  // Use embroider if it's present (it can get added by ember-try)
-  if ('@embroider/core' in app.dependencies()) {
-    /* eslint-disable node/no-missing-require, node/no-extraneous-require */
-    const { Webpack } = require('@embroider/webpack');
-    const { compatBuild } = require('@embroider/compat');
-    /* eslint-enable node/no-missing-require, node/no-extraneous-require */
-    let config = {};
-    if (process.env.EMBER_TRY_SCENARIO === 'embroider-optimized') {
-      config = {
-        staticAddonTrees: true,
-        staticAddonTestSupportTrees: true,
-        staticHelpers: true,
-        staticComponents: true,
-      };
-    }
-    return compatBuild(app, Webpack, config);
-  } else {
-    return app.toTree();
-  }
+  const { maybeEmbroider } = require('@embroider/test-setup');
+  return maybeEmbroider(app);
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,8 +3,11 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function (defaults) {
+  const self = defaults.project.findAddonByName('ember-a11y-testing');
+  const autoImport = self.options.autoImport;
   let app = new EmberAddon(defaults, {
     // Add options here
+    autoImport,
   });
 
   /*
@@ -14,5 +17,6 @@ module.exports = function (defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  return app.toTree();
+  const { maybeEmbroider } = require('@embroider/test-setup');
+  return maybeEmbroider(app);
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -16,6 +16,23 @@ module.exports = function (defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  const { maybeEmbroider } = require('@embroider/test-setup');
-  return maybeEmbroider(app);
+  // Use embroider if it's present (it can get added by ember-try)
+  if ('@embroider/core' in app.dependencies()) {
+    /* eslint-disable node/no-missing-require, node/no-extraneous-require */
+    const { Webpack } = require('@embroider/webpack');
+    const { compatBuild } = require('@embroider/compat');
+    /* eslint-enable node/no-missing-require, node/no-extraneous-require */
+    let config = {};
+    if (process.env.EMBER_TRY_SCENARIO === 'embroider-optimized') {
+      config = {
+        staticAddonTrees: true,
+        staticAddonTestSupportTrees: true,
+        staticHelpers: true,
+        staticComponents: true,
+      };
+    }
+    return compatBuild(app, Webpack, config);
+  } else {
+    return app.toTree();
+  }
 };

--- a/index.js
+++ b/index.js
@@ -23,9 +23,6 @@ module.exports = {
       resolvePeerDependenciesFrom: this.parent.root,
     });
 
-    this.options = this.options || {};
-    this.options.autoImport = {};
-
     const hasMagicallyProvidedQUnit = versionChecker
       .for('ember-qunit')
       .lt('5.0.0-beta.1');
@@ -39,7 +36,10 @@ module.exports = {
     // include qunit resulting in a runtime error (qunit detects if it as
     // already be added to the window object and errors if so).
     if (hasMagicallyProvidedQUnit) {
-      this.options.autoImport.exclude.push('qunit');
+      this.options = this.options || {};
+      this.options.autoImport = {
+        exclude: ['qunit'],
+      };
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -160,5 +160,9 @@
     "Eric Kelly <heroiceric@gmail.com>",
     "Sam Selikoff <sam.selikoff@gmail.com>",
     "Renato Iwashima <renatoiwa@gmail.com>"
-  ]
+  ],
+  "volta": {
+    "node": "12.20.1",
+    "yarn": "1.22.10"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
     "broccoli-funnel": "^3.0.3",
     "broccoli-merge-trees": "^4.2.0",
     "date-and-time": "^0.14.1",
+    "ember-auto-import": "^1.10.1",
     "ember-cli-babel": "^7.21.0",
     "ember-cli-typescript": "^3.0.0",
+    "ember-cli-version-checker": "^5.1.2",
     "ember-destroyable-polyfill": "^2.0.1",
     "fs-extra": "^9.0.1",
     "validate-peer-dependencies": "^1.1.0"
@@ -45,6 +47,7 @@
     "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.1.0",
+    "@embroider/test-setup": "^0.36.0",
     "@glimmer/component": "^1.0.1",
     "@glimmer/tracking": "^1.0.1",
     "@types/ember": "^3.16.0",
@@ -97,7 +100,13 @@
     "typescript": "^4.0.0"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^2.0.0"
+    "@ember/test-helpers": "^2.0.0",
+    "qunit": ">= 2"
+  },
+  "peerDependenciesMeta": {
+    "qunit": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -10,7 +10,7 @@ const isCI = Boolean(process.env.CI);
 const isProduction = process.env.EMBER_ENV === 'production';
 
 if (isCI || isProduction) {
-  browsers.push('ie 11');
+  //browsers.push('ie 11');
 }
 
 module.exports = {

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -6,13 +6,6 @@ const browsers = [
   'last 1 Safari versions',
 ];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  //browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12150,7 +12150,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.3, semver@^7.3.4:
+semver@^7.3.4:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1927,6 +1927,14 @@
     resolve "^1.8.1"
     semver "^7.3.2"
 
+"@embroider/test-setup@^0.36.0":
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-0.36.0.tgz#67ace15d69f04f282adde38ee39e4d48208173b7"
+  integrity sha512-YXa1uPBc5caxuS9hIOLi6TihJ9QFgS9uvlXFOADFL3yDUOuvnGWAoK9a4qHsIuH/ifGJs8xIYhByhlfruB02mw==
+  dependencies:
+    lodash "^4.17.20"
+    resolve "^1.17.0"
+
 "@glimmer/component@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-1.0.1.tgz#f304b2f9cf4f2762396abed2b8962486767e0b2e"
@@ -6038,9 +6046,9 @@ electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.523:
   integrity sha512-rM0LWDIstdqfaRUADZetNrL6+zd/0NBmavbMEhBXgc2u/CC1d1GaDyN5hho29fFvBiOVFwrSWZkzmNcZnCEDog==
 
 electron-to-chromium@^1.3.649:
-  version "1.3.654"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.654.tgz#f1b82d59bdeafa65af75794356df54f92b41c4de"
-  integrity sha512-Zy2gc/c8KYFg2GkNr7Ruzh5tPEZpFm7EyXqZTFasm1YRDJtpyBRGaOuM0H3t6SuIP53qX4kNmtO9t0WjhBjE9A==
+  version "1.3.653"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.653.tgz#1d98400eba330538a7fe169808c6bf9d83c44450"
+  integrity sha512-LehOhcl74u9fkV9Un6WahJ+Xh+0FZLCCDnKYis1Olx1DX2ugRww5PJicE65OG8yznMj8EOQZRcz6FSV1xKxqsA==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -6055,7 +6063,7 @@ elliptic@^6.5.3:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-ember-auto-import@^1.10.0, ember-auto-import@^1.7.0:
+ember-auto-import@^1.10.0, ember-auto-import@^1.10.1, ember-auto-import@^1.7.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.10.1.tgz#6c93a875e494aa0a58b759867d3f20adfd514ae3"
   integrity sha512-7bOWzPELlVwdWDOkB+phDIjg8BNW+/2RiLLQ+Xa/eIvCLT4ABYhHV5wqW5gs5BnXTDVLfE4ddKZdllnGuPGGDQ==
@@ -6459,6 +6467,15 @@ ember-cli-version-checker@^5.1.1:
   dependencies:
     resolve-package-path "^2.0.0"
     semver "^7.3.2"
+    silent-error "^1.1.1"
+
+ember-cli-version-checker@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-5.1.2.tgz#649c7b6404902e3b3d69c396e054cea964911ab0"
+  integrity sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==
+  dependencies:
+    resolve-package-path "^3.1.0"
+    semver "^7.3.4"
     silent-error "^1.1.1"
 
 ember-cli@^3.20.0:
@@ -12133,7 +12150,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.4:
+semver@^7.1.3, semver@^7.3.4:
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==


### PR DESCRIPTION
When parent applications are using ember-qunit > 5 this causes an invalid lookup for qunit in requirejs because ember-qunit no longer provides the AMD shim for qunit and instead uses ember-auto-import. This change conditionally uses ember-auto-import if that shim is present or not along with adding test cases for general embroider compatibility.

Related issue: https://github.com/ember-cli/ember-exam/issues/634