### PR TITLE
Unpin ember-qunit, fix testing container CSS overrides

### DIFF
--- a/content-for/test-head-footer.html
+++ b/content-for/test-head-footer.html
@@ -1,7 +1,7 @@
 <style>
   /* *
    * We need to modify the testing environment a bit to ensure accurate
-   * results. This is because some browser modify styles when elements are
+   * results. This is because some browsers modify styles when elements are
    * smaller than a certain size to help with accessibility
    */
 
@@ -12,19 +12,20 @@
 
   /* We position the testing container to be the entire screen */
   .axe-running #ember-testing-container {
-    position: static !important;
-    background: transparent;
-    bottom: auto;
-    right: auto;
-    width: auto;
-    height: auto;
+    position: fixed!important;
+    width: 100%;
+    height: 100%;
     overflow: auto;
     z-index: 9999;
     border: none;
+    right: 0;
   }
 
   /* Reset the zoom on the actual application so that everything is normal */
   .axe-running #ember-testing-container #ember-testing {
-    zoom: 1;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    transform: scale(1);
   }
 </style>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postpublish": "ember ts:clean"
   },
   "dependencies": {
-    "axe-core": "^4.0.1",
+    "axe-core": "^4.1.2",
     "body-parser": "^1.19.0",
     "broccoli-funnel": "^3.0.3",
     "broccoli-merge-trees": "^4.2.0",
@@ -73,7 +73,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "5.0.0",
+    "ember-qunit": "^5.1.3",
     "ember-radio-button": "^2.0.1",
     "ember-resolver": "^8.0.2",
     "ember-sinon": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3313,10 +3313,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
-axe-core@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.0.1.tgz#e337c2ed1e6fe73920166d8b0b0b352e1b50d8ae"
-  integrity sha512-OSCABHvSNDleKqJP7DUwEBvMVbr/gtOj2vCDoKKz967fxe9WqtCZLo3IRNOO2fJcu+eSFsu8aAToHfIY7sPLaw==
+axe-core@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.2.tgz#7cf783331320098bfbef620df3b3c770147bc224"
+  integrity sha512-V+Nq70NxKhYt89ArVcaNL9FDryB3vQOd+BFXZIfO3RP6rwtj+2yqqqdHEkacutglPaZLkJeuXKCjCJDMGPtPqg==
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -6063,7 +6063,7 @@ elliptic@^6.5.3:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-ember-auto-import@^1.10.0, ember-auto-import@^1.10.1, ember-auto-import@^1.7.0:
+ember-auto-import@^1.10.0, ember-auto-import@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.10.1.tgz#6c93a875e494aa0a58b759867d3f20adfd514ae3"
   integrity sha512-7bOWzPELlVwdWDOkB+phDIjg8BNW+/2RiLLQ+Xa/eIvCLT4ABYhHV5wqW5gs5BnXTDVLfE4ddKZdllnGuPGGDQ==
@@ -6158,7 +6158,7 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-
     rimraf "^3.0.1"
     semver "^5.5.0"
 
-ember-cli-babel@^7.23.0:
+ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1:
   version "7.23.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.23.1.tgz#d1517228ede08a5d4b045c78a7429728e956b30b"
   integrity sha512-qYggmt3hRs6QJ6cRkww3ahMpyP8IEV2KFrIRO/Z6hu9MkE/8Y28Xd5NjQl6fPV3oLoG0vwuHzhNe3Jr7Wec8zw==
@@ -6628,16 +6628,16 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-qunit@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-5.0.0.tgz#86a435fe2d0f799af4beba27f2a56b12ebad81ee"
-  integrity sha512-DqynQmvz0/p7AjpBt5s+wwe83h9XxlCDVwQCCGAgrZeAsJB4GWU6WcBZL3lQfDU79LFLN8YBBvnQwBU84UH8cw==
+ember-qunit@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-5.1.3.tgz#73de924c6c698eaed4adaaab257793741f2d666f"
+  integrity sha512-vz56bX/ciBZPNXl1l3jDNo9O0YBdVXtt3kqXpmEurNAlggmhdAJyAFTVZaWLtZYIfLuSdlHEMPwOzYmjqhd7fQ==
   dependencies:
     broccoli-funnel "^3.0.3"
     broccoli-merge-trees "^3.0.2"
     common-tags "^1.8.0"
-    ember-auto-import "^1.7.0"
-    ember-cli-babel "^7.23.0"
+    ember-auto-import "^1.10.1"
+    ember-cli-babel "^7.23.1"
     ember-cli-test-loader "^3.0.0"
     resolve-package-path "^3.1.0"
     silent-error "^1.1.1"


### PR DESCRIPTION
Related to PRs https://github.com/ember-a11y/ember-a11y-testing/pull/234 and https://github.com/emberjs/ember-qunit/pull/817.

Now that the ember testing container issues have been resolved, it is no longer necessary to pin `ember-qunit` to v5.0.0. I've taken this opportunity to also bump `axe-core` to the latest version (4.1.2) and fix the a11y related container CSS styles so that test results are consistent between standard and fullscreen modes. (I'm not entirely sure how these were even working properly before with the `static` CSS positioning.)

Verified all tests pass and no regressions have been introduced by running these changes through several apps that are actively using the addon.