### PR TITLE
Updating README to indicate the need to use query param with global setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ setupGlobalA11yHooks(() => true);
 start();
 ```
 
-:information_source: It's important to note that you must also use the [`enableA11yAudit`](#force-running-audits) query parameter in order to force audits. This setting is require \_in addition to\* any invocation strategy you provide.
+:information_source: It's important to note that you must also use the [`enableA11yAudit`](#force-running-audits) query parameter in order to force audits. This setting is required in addition to any invocation strategy you provide.
 
 #### Setting Options using `setRunOptions`
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ setupGlobalA11yHooks(() => true);
 start();
 ```
 
+:information_source: It's important to note that you must also use the [`enableA11yAudit`](#force-running-audits) query parameter in order to force audits. This setting is require \_in addition to\* any invocation strategy you provide.
+
 #### Setting Options using `setRunOptions`
 
 You can provide options to axe-core for your tests using the `setRunOptions` API. This API is helpful if you don't have access to the `a11yAudit` calls directly, such as when using the `setupGlobalA11yHooks`, or if you want to set the same options for all tests in a module.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ setupGlobalA11yHooks(() => true);
 start();
 ```
 
-:information_source: It's important to note that you must also use the [`enableA11yAudit`](#force-running-audits) query parameter in order to force audits. This setting is required in addition to any invocation strategy you provide.
+:warning: It's important to note that you must also use the [`enableA11yAudit`](#force-running-audits) query parameter in order to force audits. This setting is required in addition to any invocation strategy you provide.
 
 #### Setting Options using `setRunOptions`
 


### PR DESCRIPTION
It's currently not clear from the docs that when using `setupGlobalA11yHooks`, you also need to ensure you're using the `enableA11yAudit` query param in addition to an invocation strategy to ensure the hooks will run. This PR adds this information to the docs.

[Rendered](https://github.com/ember-a11y/ember-a11y-testing/blob/update-readme-global-setup/README.md)