### PR TITLE
Correct link to axe-core API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Usage of `ember-a11y-testing` in your tests can be done in one of two ways:
 ### axe Options
 
 When using the `a11yAudit` helper, you can pass in `axe-core` options.
-These options are documented in the [axe-core API docs](https://www.deque.com/axe/axe-for-web/documentation/api-documentation/#options-parameter).
+These options are documented in the [axe-core API docs](https://www.deque.com/axe/core-documentation/api-documentation/#user-content-options-parameter).
 The rule definitions are documented on [dequeuniversity.com/rules](https://dequeuniversity.com/rules/axe/4.0).
 
 Each of the following sections individually details how to set aXe options for your tests.


### PR DESCRIPTION
Updates the URL to the axe-core API docs.  The previous link, while it properly redirected the path, brought you to the top of the page (the element id linked by the hash must have changed at some point)