### PR TITLE
Fixes duplicate axe-core inclusions in host apps

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,9 @@ module.exports = {
       .for('ember-qunit')
       .lt('5.0.0-beta.1');
 
+    // Prevent duplicate axe-core inclusions in host application
+    const exclude = ['axe-core'];
+
     // Ember-qunit < 5 provides an AMD shim for qunit but newer version now use
     // ember-auto-import to include qunit. This means that qunit is no
     // longer available for addons (if the parent app is using ember-qunit > 5) to
@@ -36,11 +39,11 @@ module.exports = {
     // include qunit resulting in a runtime error (qunit detects if it as
     // already be added to the window object and errors if so).
     if (hasMagicallyProvidedQUnit) {
-      this.options = this.options || {};
-      this.options.autoImport = {
-        exclude: ['qunit'],
-      };
+      exclude.push('qunit');
     }
+
+    this.options = this.options || {};
+    this.options.autoImport = { exclude };
   },
 
   /**


### PR DESCRIPTION
Fixes https://github.com/ember-a11y/ember-a11y-testing/issues/248. Verified working with a couple of host apps, but I'm not sure if there are any other subtleties or nuances that need to be covered.