### PR TITLE
Removes unnecessary, legacy build code for inclusion of axe dependencies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,13 +23,13 @@ module.exports = {
 
     const hasMagicallyProvidedQUnit = versionChecker
       .for('ember-qunit')
-      .lt('5.1.4');
+      .lt('5.0.0-beta.1');
 
     // Ember-qunit < 5 provides an AMD shim for qunit but newer version now use
     // ember-auto-import to include qunit. This means that qunit is no
     // longer available for addons (if the parent app is using ember-qunit > 5) to
     // directly import under embroider unless they are using ember-auto-import
-    // themselves. This condidionally falls back to not using ember-auto-import
+    // themselves. This conditionally falls back to not using ember-auto-import
     // when the parent app is providing qunit because without this we would double
     // include qunit resulting in a runtime error (qunit detects if it as
     // already be added to the window object and errors if so).

--- a/index.js
+++ b/index.js
@@ -25,6 +25,15 @@ module.exports = {
       .for('ember-qunit')
       .lt('5.0.0-beta.1');
 
+    this.options = this.options || {};
+    this.options.autoImport = {
+      webpack: {
+        module: {
+          noParse: /\baxe\.js$/,
+        },
+      },
+    };
+
     // Ember-qunit < 5 provides an AMD shim for qunit but newer version now use
     // ember-auto-import to include qunit. This means that qunit is no
     // longer available for addons (if the parent app is using ember-qunit > 5) to
@@ -34,10 +43,7 @@ module.exports = {
     // include qunit resulting in a runtime error (qunit detects if it as
     // already be added to the window object and errors if so).
     if (hasMagicallyProvidedQUnit) {
-      this.options = this.options || {};
-      this.options.autoImport = {
-        exclude: ['qunit'],
-      };
+      this.options.autoImport.exclude = ['qunit'];
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -2,8 +2,6 @@
 
 const path = require('path');
 const fs = require('fs');
-const Funnel = require('broccoli-funnel');
-const MergeTrees = require('broccoli-merge-trees');
 const VersionChecker = require('ember-cli-version-checker');
 const validatePeerDependencies = require('validate-peer-dependencies');
 const setupMiddleware = require('./setup-middleware');
@@ -25,7 +23,7 @@ module.exports = {
 
     const hasMagicallyProvidedQUnit = versionChecker
       .for('ember-qunit')
-      .lt('5.0.0-beta.1');
+      .lt('5.1.4');
 
     // Ember-qunit < 5 provides an AMD shim for qunit but newer version now use
     // ember-auto-import to include qunit. This means that qunit is no
@@ -41,31 +39,6 @@ module.exports = {
         exclude: ['qunit'],
       };
     }
-  },
-
-  /**
-   * Includes axe-core in builds that have tests. It includes the un-minified
-   * version in case of a need to debug.
-   * @override
-   */
-  included: function (app) {
-    this._super.included.apply(this, arguments);
-
-    if (app.tests) {
-      let type = { type: 'test' };
-      app.import('vendor/axe-core/axe.js', type);
-      app.import('vendor/shims/axe-core.js', type);
-    }
-  },
-
-  treeForVendor: function (tree) {
-    let axePath = path.dirname(require.resolve('axe-core'));
-    let axeTree = new Funnel(axePath, {
-      files: ['axe.js'],
-      destDir: 'axe-core',
-    });
-
-    return new MergeTrees([tree, axeTree]);
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -32,8 +32,6 @@
   "dependencies": {
     "axe-core": "^4.1.2",
     "body-parser": "^1.19.0",
-    "broccoli-funnel": "^3.0.3",
-    "broccoli-merge-trees": "^4.2.0",
     "date-and-time": "^0.14.1",
     "ember-auto-import": "^1.11.2",
     "ember-cli-babel": "^7.26.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-qunit": "^5.1.3",
+    "ember-qunit": "^5.1.4",
     "ember-radio-button": "^2.0.1",
     "ember-resolver": "^8.0.2",
     "ember-sinon": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postpublish": "ember ts:clean"
   },
   "dependencies": {
-    "axe-core": "^4.1.2",
+    "axe-core": "^4.1.4",
     "body-parser": "^1.19.0",
     "date-and-time": "^0.14.1",
     "ember-auto-import": "^1.11.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "validate-peer-dependencies": "^1.1.0"
   },
   "devDependencies": {
-    "@ember/jquery": "^1.1.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.1.0",
     "@embroider/test-setup": "^0.39.0",

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,6 @@
     },
     {
       "packageNames": [
-        "broccoli-funnel",
         "ember-ajax",
         "ember-cli",
         "ember-cli-babel",

--- a/vendor/shims/axe-core.js
+++ b/vendor/shims/axe-core.js
@@ -1,9 +1,0 @@
-(function () {
-  function vendorModule() {
-    'use strict';
-
-    return self['axe'];
-  }
-
-  define('axe-core', [], vendorModule);
-})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5992,10 +5992,10 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
-ember-qunit@^5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-5.1.3.tgz#73de924c6c698eaed4adaaab257793741f2d666f"
-  integrity sha512-vz56bX/ciBZPNXl1l3jDNo9O0YBdVXtt3kqXpmEurNAlggmhdAJyAFTVZaWLtZYIfLuSdlHEMPwOzYmjqhd7fQ==
+ember-qunit@^5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-5.1.4.tgz#bc69f963a0f5409ce33bee1e4d8146b1407147bf"
+  integrity sha512-L8L3TA5UYdsoJl9If88CU6Liu5Kr76uEpXimeJIyjoRX2kI57YWI2/76uiW7UU0qdYfvcmVazgd+MJGj9aB2JA==
   dependencies:
     broccoli-funnel "^3.0.3"
     broccoli-merge-trees "^3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1062,18 +1062,6 @@
   resolved "https://registry.yarnpkg.com/@ember/edition-utils/-/edition-utils-1.2.0.tgz#a039f542dc14c8e8299c81cd5abba95e2459cfa6"
   integrity sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==
 
-"@ember/jquery@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ember/jquery/-/jquery-1.1.0.tgz#33d062610a5ceaa5c5c8a3187f870d47d6595940"
-  integrity sha512-zePT3LiK4/2bS4xafrbOlwoLJrDFseOZ95OOuVDyswv8RjFL+9lar+uxX6+jxRb0w900BcQSWP/4nuFSK6HXXw==
-  dependencies:
-    broccoli-funnel "^2.0.2"
-    broccoli-merge-trees "^3.0.2"
-    ember-cli-babel "^7.11.1"
-    ember-cli-version-checker "^3.1.3"
-    jquery "^3.4.1"
-    resolve "^1.11.1"
-
 "@ember/optional-features@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-2.0.0.tgz#c809abd5a27d5b0ef3c6de3941334ab6153313f0"
@@ -1308,6 +1296,13 @@
   version "0.44.0"
   resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
   integrity sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==
+
+"@glimmer/vm-babel-plugins@0.77.5":
+  version "0.77.5"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.77.5.tgz#daffb6507aa6b08ec36f69d652897d339fdd0007"
+  integrity sha512-jTBM7fJMrIEy4/bCeI8e7ypR+AuWYzLA+KORCGbnTJtL/NYg4G8qwhQAZBtg1d3KmoqyqaCsyqE6f4/tzJO4eQ==
+  dependencies:
+    babel-plugin-debug-macros "^0.3.4"
 
 "@glimmer/vm@^0.42.2":
   version "0.42.2"
@@ -5490,7 +5485,7 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.23.0, ember-
     rimraf "^3.0.1"
     semver "^5.5.0"
 
-ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.11.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.22.1, ember-cli-babel@^7.7.3:
   version "7.22.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.22.1.tgz#cad28b89cf0e184c93b863d09bc5ba4ce1d2e453"
   integrity sha512-kCT8WbC1AYFtyOpU23ESm22a+gL6fWv8Nzwe8QFQ5u0piJzM9MEudfbjADEaoyKTrjMQTDsrWwEf3yjggDsOng==
@@ -6078,14 +6073,15 @@ ember-source-channel-url@^3.0.0:
     node-fetch "^2.6.0"
 
 ember-source@^3.20.4:
-  version "3.20.4"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.20.4.tgz#582545ae3b20de5ffd9f8b43c42c94815e592291"
-  integrity sha512-ycWlaq7W63S3Nh7pMRU4oXNirBB9MbNGDN6hUgs3/qc1gjOUVGfGv0p2NPVcKXgqWtbiqrWGqCbp1iTay2MUpA==
+  version "3.26.1"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.26.1.tgz#8c9e8a314fb0da447b944d64f9d92a80a628d7b5"
+  integrity sha512-5/NATBo5h9m1N52ITVksmjtGlYhGHLl4lDErAWv5/DC9zYe9ZR93NtymR6PEqrRilXc2x0KWd3NlOsWUoJRUOw==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"
     "@babel/plugin-transform-object-assign" "^7.8.3"
     "@ember/edition-utils" "^1.2.0"
+    "@glimmer/vm-babel-plugins" "0.77.5"
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-filter-imports "^4.0.0"
     broccoli-concat "^4.2.4"
@@ -6093,7 +6089,7 @@ ember-source@^3.20.4:
     broccoli-funnel "^2.0.2"
     broccoli-merge-trees "^4.2.0"
     chalk "^4.0.0"
-    ember-cli-babel "^7.19.0"
+    ember-cli-babel "^7.23.0"
     ember-cli-get-component-path-option "^1.0.0"
     ember-cli-is-package-missing "^1.0.0"
     ember-cli-normalize-entity-name "^1.0.0"
@@ -6102,9 +6098,9 @@ ember-source@^3.20.4:
     ember-cli-version-checker "^5.1.1"
     ember-router-generator "^2.0.0"
     inflection "^1.12.0"
-    jquery "^3.5.0"
+    jquery "^3.5.1"
     resolve "^1.17.0"
-    semver "^6.1.1"
+    semver "^7.3.4"
     silent-error "^1.1.1"
 
 ember-template-lint@^2.9.1:
@@ -8615,10 +8611,10 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jquery@^3.4.1, jquery@^3.5.0:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+jquery@^3.5.1:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
 js-reporters@1.2.3:
   version "1.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2556,10 +2556,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axe-core@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.2.tgz#7cf783331320098bfbef620df3b3c770147bc224"
-  integrity sha512-V+Nq70NxKhYt89ArVcaNL9FDryB3vQOd+BFXZIfO3RP6rwtj+2yqqqdHEkacutglPaZLkJeuXKCjCJDMGPtPqg==
+axe-core@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
+  integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
 
 babel-code-frame@^6.26.0:
   version "6.26.0"


### PR DESCRIPTION
should fix #248

- checked with @ef4 & the lines removed are per his recommendation (as the author of `ember-auto-import`) - seems we were doing some redundant things that `ember-auto-import` was already providing. 
- updates the version of `ember-qunit`

I did notice that some of the dummy app tests are failing. Perhaps we should plan to revisit the app and update it. I'll make a new issue for that.