### PR TITLE
Don't print to the console when there are no issues

### DIFF
--- a/addon-test-support/logger.ts
+++ b/addon-test-support/logger.ts
@@ -159,41 +159,43 @@ export function storeResults(results: AxeResults) {
  * @public
  */
 export function printResults() {
-  console.group('%cAxe issues', serious);
-  testSuiteResults.forEach((results) => {
-    results.forEach((result) => {
-      let fmt: string;
-      switch (result.impact) {
-        case 'critical':
-          fmt = critical;
-          break;
-        case 'serious':
-          fmt = serious;
-          break;
-        case 'moderate':
-          fmt = moderate;
-          break;
-        case 'minor':
-          fmt = minor;
-          break;
-        default:
-          fmt = minor;
-          break;
-      }
-      console.groupCollapsed(
-        '%c%s: %c%s %s',
-        fmt,
-        result.impact,
-        defaultReset,
-        result.help,
-        result.helpUrl
-      );
-      result.nodes.forEach((node) => {
-        failureSummary(node, 'any');
-        failureSummary(node, 'none');
+  if (testSuiteResults.length) {
+    console.group('%cAxe issues', serious);
+    testSuiteResults.forEach((results) => {
+      results.forEach((result) => {
+        let fmt: string;
+        switch (result.impact) {
+          case 'critical':
+            fmt = critical;
+            break;
+          case 'serious':
+            fmt = serious;
+            break;
+          case 'moderate':
+            fmt = moderate;
+            break;
+          case 'minor':
+            fmt = minor;
+            break;
+          default:
+            fmt = minor;
+            break;
+        }
+        console.groupCollapsed(
+          '%c%s: %c%s %s',
+          fmt,
+          result.impact,
+          defaultReset,
+          result.help,
+          result.helpUrl
+        );
+        result.nodes.forEach((node) => {
+          failureSummary(node, 'any');
+          failureSummary(node, 'none');
+        });
+        console.groupEnd();
       });
-      console.groupEnd();
     });
-  });
-  console.groupEnd();
+    console.groupEnd();
+  }
 }


### PR DESCRIPTION
printResults checks if testSuiteResults exists before printing to the console.

Currently printing `Axe issues` when there aren't any is confusing and adds noise.

![image](https://user-images.githubusercontent.com/1477357/116357224-1c40f080-a7b1-11eb-8c6b-06e2dae63c2b.png)