### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,7 @@
 /.eslintrc.js
 /.git/
 /.gitignore
+/.prettierrc
 /.template-lintrc.js
 /.travis.yml
 /.watchmanconfig
@@ -24,7 +25,9 @@
 /testem.js
 /tests/
 /node-tests/
+/renovate.json
 /yarn.lock
+/yarn-error.log
 .gitkeep
 
 # ember-try


### PR DESCRIPTION
There are few extra files (notably 619.5kB yarn-error.log) which should not be part of published package.