### PR TITLE
Fixes issue when violations count is reported to be 0

### DIFF
--- a/addon-test-support/format-violation.ts
+++ b/addon-test-support/format-violation.ts
@@ -3,8 +3,8 @@ import type { Result } from 'axe-core';
 /**
  * Formats the axe violation for human consumption
  *
- * @param {AxeViolation} violation
- * @param {string | string[]} markup (optional) string of HTML relevant to the violation
+ * @param {Partial<Result>} violation
+ * @param {string[]} markup (optional) string of HTML relevant to the violation
  */
 export default function formatViolation(
   violation: Partial<Result>,

--- a/addon-test-support/format-violation.ts
+++ b/addon-test-support/format-violation.ts
@@ -7,14 +7,9 @@ import type { Result } from 'axe-core';
  * @param {string | string[]} markup (optional) string of HTML relevant to the violation
  */
 export default function formatViolation(
-  violation: Partial<Result> | undefined,
-  markup?: string | string[]
+  violation: Partial<Result>,
+  markup: string[]
 ) {
-  if (!violation) {
-    throw new Error(
-      'formatViolation called without required parameter: violation'
-    );
-  }
   if (!violation.impact || !violation.help || !violation.helpUrl) {
     throw new Error(
       'formatViolation called with improper structure of parameter: violation. Required properties: impact, help, helpUrl.'
@@ -22,19 +17,15 @@ export default function formatViolation(
   }
 
   let count = 1;
+  let formattedMarkup = '';
 
-  if (markup) {
-    if (Array.isArray(markup)) {
-      count = markup.length;
-      markup = markup.join('\n');
-    }
-    markup = ` Offending nodes are: \n${markup}`;
-  } else {
-    markup = '';
+  if (markup.length) {
+    count = markup.length;
+    formattedMarkup = ` Offending nodes are: \n${markup.join('\n')}`;
   }
 
   let plural = count === 1 ? '' : 's';
   let violationCount = `Violated ${count} time${plural}.`;
 
-  return `[${violation.impact}]: ${violation.help} \n${violationCount}${markup}\n${violation.helpUrl}`;
+  return `[${violation.impact}]: ${violation.help} \n${violationCount}${formattedMarkup}\n${violation.helpUrl}`;
 }

--- a/tests/unit/format-violation-test.ts
+++ b/tests/unit/format-violation-test.ts
@@ -22,7 +22,7 @@ module('Unit | Utils | formatViolation', function () {
       ],
     };
 
-    let message = formatViolation(violation, violation.nodes[0].html);
+    let message = formatViolation(violation, [violation.nodes[0].html]);
     let expected = `[critical]: it should be better \nViolated 1 time. Offending nodes are: \n<input type="text">\nhttp://example.com`;
     assert.equal(message, expected);
   });
@@ -38,7 +38,7 @@ module('Unit | Utils | formatViolation', function () {
       nodes: [],
     };
 
-    let message = formatViolation(violation);
+    let message = formatViolation(violation, []);
     let expected = `[critical]: it should be better \nViolated 1 time.\nhttp://example.com`;
     assert.equal(message, expected);
   });
@@ -64,15 +64,7 @@ module('Unit | Utils | formatViolation', function () {
     let expected = /formatViolation called with improper structure of parameter: violation. Required properties: impact, help, helpUrl./;
 
     assert.throws(function () {
-      formatViolation(violation, violation.nodes[0].html);
-    }, expected);
-  });
-
-  test('validates violation parameter exists', function (assert) {
-    let expected = /formatViolation called without required parameter: violation/;
-
-    assert.throws(function () {
-      formatViolation(undefined);
+      formatViolation(violation, [violation.nodes[0].html]);
     }, expected);
   });
 });


### PR DESCRIPTION
It's possible when encountering violations that the violations' node array is empty. In that case, when we try to format the violation, we output a 0 count for violations due to the fact we try to infer the violations count occurrences through the presence of node's html.

In addition, the `formatViolation` tests were not indicative of the actual execution of this function. The function signature indicated that both violation and markup could be either undefined or optional respectively, but this did not reflect how this was used in practice. The two parameters are always required, and this misalignment helped manifest this bug.

This PR addresses both fixing the issue, and updating the tests to better reflect the usage.