### PR TITLE
Documentation: Clarify that options are for axe.run, remove invalid `checks` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Usage of `ember-a11y-testing` in your tests can be done in one of two ways:
 
 ### axe Options
 
-When using the `a11yAudit` helper, you can pass in `axe-core` options.
+When using the `a11yAudit` helper, you can pass in `axe-core` options that are passed to `axe.run`.
 These options are documented in the [axe-core API docs](https://www.deque.com/axe/core-documentation/api-documentation/#user-content-options-parameter).
 The rule definitions are documented on [dequeuniversity.com/rules](https://dequeuniversity.com/rules/axe/4.0).
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,6 @@ setRunOptions({
   rules: {
     region: { enabled: true },
   },
-  checks: {
-    'color-contrast': {
-      options: {
-        noScroll: true,
-      },
-    },
-  },
 });
 ```
 
@@ -122,13 +115,6 @@ module('some test module', function (hooks) {
     setRunOptions({
       rules: {
         region: { enabled: true },
-      },
-      checks: {
-        'color-contrast': {
-          options: {
-            noScroll: true,
-          },
-        },
       },
     });
   });
@@ -148,13 +134,6 @@ module('some test module', function (hooks) {
     setRunOptions({
       rules: {
         region: { enabled: true },
-      },
-      checks: {
-        'color-contrast': {
-          options: {
-            noScroll: true,
-          },
-        },
       },
     });
 


### PR DESCRIPTION
`axe.run` accepts different options from `axe.configure`. This PR modifies documentation to note that the options passed to ember-a11y-testing are for `axe.run`, and removes an invalid `checks` property that is potentially misleading.

See: https://github.com/dequelabs/axe-core/commit/12767735015a082f46ecb066f018a4203c6d48c7

Also wondering, would it be possible to expose a way to pass options to `axe.configure`?