### PR TITLE
Prevent deletion of a11y audit reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ This addon provides middleware - code that allows the browser to talk to the nod
 
 The middleware reporter writes the results containing all violations detected in all tests to a JSON file stored in a directory, `ember-a11y-report`, in your application or addon's root directory.
 
+:warning: **Audit report files get generated in an additive manner, typically resulting in the `a11y-audit-report` directory growing in size as subsequent test suites are run. Environments with specific space size restrictions will require an explicit strategy to manage the deletion of older reports, as this addon no longer does so.**
+
 To use the middleware reporter, import `setupMiddlewareReporter` and invoke in your `tests/test-helper.js` file:
 
 ```js

--- a/setup-middleware.js
+++ b/setup-middleware.js
@@ -3,7 +3,7 @@
 const bodyParser = require('body-parser').json({ limit: '50mb' });
 const path = require('path');
 const date = require('date-and-time');
-const { ensureDirSync, writeJsonSync, emptyDirSync } = require('fs-extra');
+const { ensureDirSync, writeJsonSync } = require('fs-extra');
 
 let outputDir;
 
@@ -29,7 +29,6 @@ function setupMiddleware(app, options) {
   outputDir = path.join(options.root, 'ember-a11y-report');
 
   ensureDirSync(outputDir);
-  emptyDirSync(outputDir);
 
   app.post(
     '/report-violations',


### PR DESCRIPTION
Current invocations of the middleware reporter cause the deletion of all prior reports from the `ember-a11y-report` directory. This behavior is undesirable as it causes an unexpected removal of prior logs, which may lead to a loss of data if the reports aren't backed up. It also makes it difficult to use with test executions that are spread across multiple partitions, in that only the reports from the last partition get archived. This change removes file deletion so that subsequent reports are additive and includes documentation about the change in behavior.

I think this update merits some discussion on whether it constitutes a major version upgrade. While it isn't necessarily a breaking change, there may be some consumers that depend on auto file deletion and will be unaware that it's something that they may need to explicitly manage going forward.

