### PR TITLE
Fixes deprecate call to include for and since props

### DIFF
--- a/addon-test-support/audit-if.ts
+++ b/addon-test-support/audit-if.ts
@@ -23,6 +23,10 @@ export default function a11yAuditIf(
     {
       id: 'ember-a11y-testing-deprecated-a11y-audit-if',
       until: '5.0.0',
+      for: 'ember-a11y-testing',
+      since: {
+        enabled: '4.0.0',
+      },
     }
   );
 

--- a/types/ember-debug.d.ts
+++ b/types/ember-debug.d.ts
@@ -1,0 +1,35 @@
+import '@ember/debug';
+
+export type DeprecationStages = 'available' | 'enabled';
+
+declare module '@ember/debug' {
+  export function deprecate(
+    message: string,
+    test: boolean,
+    options: {
+      /**
+       * A unique id for this deprecation. The id can be used by Ember debugging
+       * tools to change the behavior (raise, log or silence) for that specific
+       * deprecation. The id should be namespaced by dots, e.g.
+       * `"view.helper.select"`.
+       */
+      id: string;
+      /**
+       * The version of Ember when this deprecation warning will be removed.
+       */
+      until: string;
+      /**
+       * A namespace for the deprecation, usually the package name
+       */
+      for: string;
+      /**
+       * Describes when the deprecation became available and enabled
+       */
+      since: Partial<Record<DeprecationStages, string>>;
+      /**
+       * An optional url to the transition guide on the emberjs.com website.
+       */
+      url?: string | undefined;
+    }
+  ): void;
+}


### PR DESCRIPTION
Fixes the current usages of deprecate to include `for` and `since`. This will ensure CI passes on canary.