### PR TITLE
Adds get-port to ensure we have an available port

### DIFF
--- a/node-tests/setup-middleware-test.js
+++ b/node-tests/setup-middleware-test.js
@@ -3,6 +3,7 @@ const fetch = require('node-fetch');
 const fs = require('fs');
 const tmp = require('tmp');
 const express = require('express');
+const getPort = require('get-port');
 const readJSONSync = require('fs-extra').readJSONSync;
 const {
   setupMiddleware,
@@ -29,8 +30,9 @@ QUnit.module('setupMiddleware', function (hooks) {
   let tmpDir;
   let app;
   let server;
+  let port;
 
-  hooks.beforeEach(function () {
+  hooks.beforeEach(async function () {
     tmpDir = createTmpDir();
     app = express();
 
@@ -41,7 +43,8 @@ QUnit.module('setupMiddleware', function (hooks) {
       reportDir: 'ember-a11y-report',
     });
 
-    server = app.listen(3000);
+    port = await getPort({ port: 3000 });
+    server = app.listen(port);
   });
 
   hooks.afterEach(function () {
@@ -53,7 +56,7 @@ QUnit.module('setupMiddleware', function (hooks) {
     async function (assert) {
       let data = [buildResult(violationsFixture)];
 
-      let json = await fetch('http://localhost:3000/report-violations', {
+      let json = await fetch(`http://localhost:${port}/report-violations`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "express": "^4.17.1",
+    "get-port": "5",
     "loader.js": "^4.7.0",
     "node-fetch": "^2.6.0",
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "express": "^4.17.1",
-    "get-port": "5",
+    "get-port": "^5.1.1",
     "loader.js": "^4.7.0",
     "node-fetch": "^2.6.0",
     "npm-run-all": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7118,7 +7118,7 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
-get-port@5:
+get-port@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
   integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7118,6 +7118,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
+get-port@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
+  integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"


### PR DESCRIPTION
The port for the middleware tests was hardcoded, and when running them locally this port was in use. This caused the tests to fail, and it forced me to debug locally to determine the cause. 

Adding automated port discovery will alleviate this.