### PR TITLE
Drop Node.js 10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ individual tests using an `a11yAudit()` test helper.
 ## Compatibility
 
 - Ember.js v3.8.0 or above
-- Node.js v10 or above
+- Node.js v12 or above
 - `@ember/test-helpers` v2.0.0 or above
 
 Note: we enforce a peerDependency of `@ember/test-helpers`. If you encounter the following message:

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     }
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "12.* || 14.* || >= 16"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
#325 requires major release, so good time to drop old Node.js version support.