### PR TITLE
Remove `fuse.js` resolution from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,9 +61,6 @@
     "prepublishOnly": "ember ts:precompile",
     "postpublish": "ember ts:clean"
   },
-  "resolutions": {
-    "fuse.js": "6.4.6"
-  },
   "dependencies": {
     "@ember/test-waiters": "^2.4.3 || ^3.0.0",
     "@scalvert/ember-setup-middleware-reporter": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7685,10 +7685,10 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-fuse.js@6.4.6, fuse.js@^6.4.6:
-  version "6.4.6"
-  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.4.6.tgz#62f216c110e5aa22486aff20be7896d19a059b79"
-  integrity sha512-/gYxR/0VpXmWSfZOIPS3rWwU8SHgsRTwWuXhyb2O6s7aRuVtHtxCkR33bNYu3wyLyNx/Wpv0vU7FZy8Vj53VNw==
+fuse.js@^6.4.6:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.5.2.tgz#3c775c456b888bc8b3a0ca10aeadef507a2790d0"
+  integrity sha512-FTJXjzNg/HqEceelMCmQgDSuZ2HPpxlgV8YZc6ptuC51DiEHhc7H1E17XnH52WUPs8wdMAbG+PQwAMFnsI9ysA==
 
 gauge@~2.7.3:
   version "2.7.4"


### PR DESCRIPTION
The underlying regression in v2.5.0 was fixed, see https://github.com/krisk/Fuse/issues/600