### PR TITLE
feat: add qunit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ export function a11yAuditIf(contextSelector, axeOptions) {
 
 #### QUnit and Testem integration
 
-You can setup a new configuration checkbox in QUnit and Testem by using the `setupQUnitA11yAudit`
+You can setup a new configuration checkbox in QUnit and Testem by using the `setupQUnitA11yAudit`.
 When the checkbox is checked, it will set `enableA11yAudit` as a query param.
 
 To use, import and invoke the setup function, passing in your QUnit instance:

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ export function a11yAuditIf(contextSelector, axeOptions) {
 
 #### QUnit and Testem integration
 
-You can setup a new configuration checkbox in QUnit and Testem by using the `setupQUnitA11yAudit`.
+You can setup a new configuration checkbox in QUnit and Testem by using the `setupQUnitA11yAuditToggle`.
 When the checkbox is checked, it will set `enableA11yAudit` as a query param.
 
 To use, import and invoke the setup function, passing in your QUnit instance:
@@ -341,11 +341,11 @@ import config from 'my-app/config/environment';
 import * as QUnit from 'qunit';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
-import { setupGlobalA11yHooks, setupQUnitA11yAudit } from 'ember-a11y-testing/test-support';
+import { setupGlobalA11yHooks, setupQUnitA11yAuditToggle } from 'ember-a11y-testing/test-support';
 setApplication(Application.create(config.APP));
 
 setupGlobalA11yHooks(() => true);
-setupQUnitA11yAudit(QUnit);
+setupQUnitA11yAuditToggle(QUnit);
 
 start();
 ```

--- a/README.md
+++ b/README.md
@@ -327,6 +327,29 @@ export function a11yAuditIf(contextSelector, axeOptions) {
 }
 ```
 
+#### QUnit and Testem integration
+
+You can setup a new configuration checkbox in QUnit and Testem by using the `setupQUnitA11yAudit`
+When the checkbox is checked, it will set `enableA11yAudit` as a query param.
+
+To use, import and invoke the setup function, passing in your QUnit instance:
+
+```js
+// tests/test-helper.js
+import Application from 'my-app/app';
+import config from 'my-app/config/environment';
+import * as QUnit from 'qunit';
+import { setApplication } from '@ember/test-helpers';
+import { start } from 'ember-qunit';
+import { setupGlobalA11yHooks, setupQUnitA11yAudit } from 'ember-a11y-testing/test-support';
+setApplication(Application.create(config.APP));
+
+setupGlobalA11yHooks(() => true);
+setupQUnitA11yAudit(QUnit);
+
+start();
+```
+
 ### Logging violations to the console
 
 This addon provides the capability of summarizing all violations found during tests, and outputting those failures to the console once the test suite is completed. To enable this functionality, import `setupConsoleLogger` and invoke in your `tests/test-helper.js` file:

--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -16,6 +16,6 @@ export {
 } from './setup-middleware-reporter';
 export { storeResults, printResults } from './logger';
 export { setupConsoleLogger } from './setup-console-logger';
-export { setupQUnitA11yAudit } from './setup-qunit';
+export { setupQUnitA11yAuditToggle } from './setup-qunit';
 
 export type { InvocationStrategy, A11yAuditReporter } from './types';

--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -16,5 +16,6 @@ export {
 } from './setup-middleware-reporter';
 export { storeResults, printResults } from './logger';
 export { setupConsoleLogger } from './setup-console-logger';
+export { setupQUnitA11yAudit } from './setup-qunit';
 
 export type { InvocationStrategy, A11yAuditReporter } from './types';

--- a/addon-test-support/setup-qunit.ts
+++ b/addon-test-support/setup-qunit.ts
@@ -1,0 +1,9 @@
+import * as QUnit from 'qunit';
+
+export function setupQUnitA11yAudit(qunit: QUnit) {
+  qunit.config.urlConfig.push({
+    id: 'enableA11yAudit',
+    label: 'A11y audit',
+    tooltip: 'Enable accessibility audit.',
+  });
+}

--- a/addon-test-support/setup-qunit.ts
+++ b/addon-test-support/setup-qunit.ts
@@ -1,6 +1,6 @@
 import * as QUnit from 'qunit';
 
-export function setupQUnitA11yAudit(qunit: QUnit) {
+export function setupQUnitA11yAuditToggle(qunit: QUnit) {
   qunit.config.urlConfig.push({
     id: 'enableA11yAudit',
     label: 'A11y audit',


### PR DESCRIPTION
# Features

## Add QUnit config

#### QUnit and Testem integration

You can setup a new configuration checkbox in QUnit and Testem by using the `setupQUnitA11yAudit`
When the checkbox is checked, it will set `enableA11yAudit` as a query param.

To use, import and invoke the setup function, passing in your QUnit instance:

```js
// tests/test-helper.js
import Application from 'my-app/app';
import config from 'my-app/config/environment';
import * as QUnit from 'qunit';
import { setApplication } from '@ember/test-helpers';
import { start } from 'ember-qunit';
import { setupGlobalA11yHooks, setupQUnitA11yAudit } from 'ember-a11y-testing/test-support';
setApplication(Application.create(config.APP));

setupGlobalA11yHooks(() => true);
setupQUnitA11yAudit(QUnit);

start();
```

----

Here is the result in Testem:

<img width="281" alt="Capture d’écran 2022-10-20 à 14 28 12" src="https://user-images.githubusercontent.com/1322081/197488623-5d61f1da-4a7f-49e6-8fc7-01ef078f3bd5.png">


