### PR TITLE
Fixes currentRouteName middleware reporter test failures

### DIFF
--- a/addon-test-support/setup-middleware-reporter.ts
+++ b/addon-test-support/setup-middleware-reporter.ts
@@ -39,6 +39,30 @@ let currentUrls: Set<string> | undefined;
 let currentRouteNames: Set<string> | undefined;
 
 /**
+ * Utility to retrieve the route name corresponding to the current test. Absorbs the emitted
+ * assertion error if route name is `null`, resulting in an empty string return value.
+ *
+ * @param getFn Function to use to derive the route name.
+ * @returns Route name or empty string.
+ */
+export function _getCurrentRouteName(getFn = currentRouteName): string {
+  let routeName = '';
+
+  try {
+    routeName = getFn();
+  } catch (error: unknown) {
+    if (
+      error instanceof Error &&
+      !/currentRouteName (\w|\s)+ string/.test(error.message)
+    ) {
+      throw error;
+    }
+  }
+
+  return routeName;
+}
+
+/**
  * A custom reporter that is invoked once per failed a11yAudit call. This can be called
  * multiple times per test, and the results are accumulated until testDone.
  *
@@ -73,7 +97,7 @@ export async function middlewareReporter(axeResults: AxeResults) {
   }
 
   currentUrls!.add(currentURL());
-  currentRouteNames!.add(currentRouteName());
+  currentRouteNames!.add(_getCurrentRouteName());
 
   axeResults.violations.forEach((violation) => {
     let rule = currentViolationsMap!.get(violation.id);

--- a/tests/unit/get-current-route-name-test.ts
+++ b/tests/unit/get-current-route-name-test.ts
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { _getCurrentRouteName } from 'ember-a11y-testing/test-support/setup-middleware-reporter';
+
+module('Unit | Utils | getCurrentRouteName', function (hooks) {
+  setupTest(hooks);
+
+  test('gets the route name for the current test', function (assert) {
+    function mockCurrentRouteName(): string {
+      return 'index';
+    }
+
+    const result = _getCurrentRouteName(mockCurrentRouteName);
+
+    assert.strictEqual(result, 'index');
+  });
+
+  test('absorbs `currentRouteName` error when route name is null', function (assert) {
+    function currentRouteNameMock(): string {
+      throw new Error('currentRouteName shoudl be a string');
+    }
+
+    const result = _getCurrentRouteName(currentRouteNameMock);
+
+    assert.strictEqual(result, '');
+  });
+
+  test('bubbles up all other emitted errors', function (assert) {
+    function mockCurrentRouteName(): string {
+      throw new Error('Catastrophic error!');
+    }
+
+    assert.throws(() => {
+      _getCurrentRouteName(mockCurrentRouteName);
+    }, /Catastrophic error!/);
+  });
+});

--- a/tests/unit/get-current-route-name-test.ts
+++ b/tests/unit/get-current-route-name-test.ts
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { _getCurrentRouteName } from 'ember-a11y-testing/test-support/setup-middleware-reporter';
 
-module('Unit | Utils | getCurrentRouteName', function (hooks) {
+module('Unit | Utils | _getCurrentRouteName', function (hooks) {
   setupTest(hooks);
 
   test('gets the route name for the current test', function (assert) {


### PR DESCRIPTION
Fixes issue #489.

The recent release of `@ember/test-helpers` v2.9.0 added an [assertion error](https://github.com/emberjs/ember-test-helpers/blob/ded104ba04e354bfefca4d0b4d2079eb70f29814/addon-test-support/%40ember/test-helpers/setup-application-context.ts#L200) that is emitted if the route name isn't available for a particular test. This results in a slew of unrelated application test failures when running the middleware reporter.

The resulting test failures typically consist of:
```sh
Promise rejected during "clicking the View Permissions button brings up the View modal": Assertion Failed: currentRouteName shoudl be a string"Source:
Error: Assertion Failed: currentRouteName shoudl be a string
    at assert (http://localhost:4444/talent/assets/vendor-static.js:32729:15)
    at currentRouteName (http://localhost:4444/talent/assets/test-support.js:22729:75)
    at middlewareReporter (http://localhost:4444/talent/assets/test-support.js:32566:61)
    at async http://localhost:4444/talent/assets/test-support.js:32499:11
    at async Promise.all (index 0)
    at async Object.<anonymous> (http://localhost:4444/talent/assets/tests.js:32489:7)"
```

The fix introduces a loose wrapper around the `currentRouteName` call, which absorbs the error, preventing it from getting emitted up to the test scope. All other behavior remains unchanged.