### PR TITLE
Disabling transitions and animations while running axe tests

### DIFF
--- a/content-for/test-head-footer.html
+++ b/content-for/test-head-footer.html
@@ -28,4 +28,13 @@
     height: 100%;
     transform: scale(1);
   }
+
+  /*
+   * Setting duration to zero so that the elements will get transitioned/animated immediately
+   * so that the gradual transition/animation will not violate any of the WCAG guidelines
+   */
+  .axe-running * {
+    transition-duration: 0s !important;
+    animation-duration: 0s !important;
+  }
 </style>

--- a/content-for/test-head-footer.html
+++ b/content-for/test-head-footer.html
@@ -30,8 +30,7 @@
   }
 
   /*
-   * Disabling animation and transition so that the elements are not evaluated
-   * while the transition/animation is in progress.
+   * Disables visual effects so that elements aren't evaluated while in animation or transition.
    */
   .axe-running * {
     animation: none !important;

--- a/content-for/test-head-footer.html
+++ b/content-for/test-head-footer.html
@@ -30,11 +30,11 @@
   }
 
   /*
-   * Setting duration to zero so that the elements will get transitioned/animated immediately
-   * so that the gradual transition/animation will not violate any of the WCAG guidelines
+   * Disabling animation and transition so that the elements are not evaluated
+   * while the transition/animation is in progress.
    */
   .axe-running * {
-    transition-duration: 0s !important;
-    animation-duration: 0s !important;
+    animation: none !important;
+    transition: none !important;
   }
 </style>


### PR DESCRIPTION
Copying the proposal that is added in #505 

With animations and transitions in place, the a11y tests can non-deterministically fail.

For eg., lets say we have a disabled button and on certain action (click of another button) we enable the button. Lets say we have a transition property set on the button to transition the background-color of the button.

Now, lets say the disabled button contrast ratio doesn't meet the AA guidelines. The a11y tests will continue to pass since the axe-core doesn't run the tests on disabled elements. In the example that i mentioned above, when the axe-core tests run as soon as the button gets enabled, it can lead to a11y violation error since the background transition might not have completed yet.

In this PR, we are disabling animation and transition so that the transitions/animations will not affect any of the axe tests
```
.axe-running * {
  animation: none !important;
  transition: none !important;
}
```