### PR TITLE
Ensures context for current URL & route middleware reporting

### DIFF
--- a/addon-test-support/setup-middleware-reporter.ts
+++ b/addon-test-support/setup-middleware-reporter.ts
@@ -74,9 +74,10 @@ export async function middlewareReporter(axeResults: AxeResults) {
     return;
   }
 
+  const context = getContext();
+
   if (!currentTestResult) {
     let { module, testName } = QUnit.config.current;
-    const context = getContext();
     if (!context) {
       throw new Error(
         'You tried to run ember-a11y-testing without calling one of the `setupTest` helpers from `@ember/test-helpers`. Please make sure your test setup calls `setupTest()`, `setupRenderingTest()`, or `setupApplicationTest()`!'
@@ -102,8 +103,10 @@ export async function middlewareReporter(axeResults: AxeResults) {
     currentRouteNames = new Set();
   }
 
-  currentUrls!.add(currentURL());
-  currentRouteNames!.add(_getCurrentRouteName());
+  if (context) {
+    currentUrls!.add(currentURL());
+    currentRouteNames!.add(_getCurrentRouteName());
+  }
 
   axeResults.violations.forEach((violation) => {
     let rule = currentViolationsMap!.get(violation.id);


### PR DESCRIPTION
## Summary
* Fixes issue #513.

In some circumstances, when using the middleware reporter, the a11y audit completes after test context has been torn down, resulting in test failures due to the thrown errors from using `currentURL` and `currentRouteName`. The fix ensures `context` exists before these two methods are called.

## Testing Done
* Local tests pass.
* Manually validated tests are no longer failing from within the context of a host app.