### PR TITLE
Allow wrapping the default reporter without having to rebuild it

### DIFF
--- a/addon-test-support/index.ts
+++ b/addon-test-support/index.ts
@@ -7,7 +7,10 @@ export {
   teardownGlobalA11yHooks,
   DEFAULT_A11Y_TEST_HELPER_NAMES,
 } from './setup-global-a11y-hooks';
-export { setCustomReporter } from './reporter';
+export {
+  setCustomReporter,
+  DEFAULT_REPORTER as _DEFAULT_REPORTER,
+} from './reporter';
 export {
   TEST_SUITE_RESULTS as _TEST_SUITE_RESULTS,
   middlewareReporter as _middlewareReporter,

--- a/addon-test-support/reporter.ts
+++ b/addon-test-support/reporter.ts
@@ -4,7 +4,7 @@ import formatViolation from './format-violation';
 import { A11yAuditReporter } from './types';
 import { storeResults } from './logger';
 
-const DEFAULT_REPORTER = async (results: AxeResults) => {
+export const DEFAULT_REPORTER = async (results: AxeResults) => {
   let violations = results.violations;
 
   storeResults(results);


### PR DESCRIPTION
We currently expose `_TEST_SUITE_RESULTS` and `_middlewareReporter` to allow customizing reporting without needing to build the entire set of reporting / middleware / test violation capture. But we don't currently allow wrapping the default reporter which hampers any ability to filter violation results (or report on them differently) while still using the core setup within default reporter.

It's probably worth thinking through ways to expose all of these items as "wrappable" more easily, but short-term I'm working on an app that could use the ability to filter results in certain scenarios