### PR TITLE
Widen `@ember/test-helpers` peer dependency declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "webpack": "^5.65.0"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^3.0.3",
+    "@ember/test-helpers": "^3.0.3 || ^4.0.2",
     "qunit": ">= 2"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
v4 of `@ember/test-helpers` was released lately, and appears to work just fine with `ember-a11y-testing` since the breaking changes in that release are irrelevant to this addon :)