### PR TITLE
fix typescript context for integration tests

### DIFF
--- a/tests/integration/helpers/a11y-audit-test.ts
+++ b/tests/integration/helpers/a11y-audit-test.ts
@@ -1,8 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
+import type { TestContext } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { a11yAudit, setEnableA11yAudit } from 'ember-a11y-testing/test-support';
+
+interface Context extends TestContext {
+  element: Element;
+}
 
 module('Integration | Helper | a11yAudit', function (hooks) {
   setupRenderingTest(hooks);
@@ -15,13 +20,13 @@ module('Integration | Helper | a11yAudit', function (hooks) {
     setEnableA11yAudit(false);
   });
 
-  test('a11yAudit runs successfully with element context', async function (assert) {
+  test('a11yAudit runs successfully with element context', async function (this: Context, assert) {
     await render(hbs`<AxeComponent/>`);
     await a11yAudit(this.element);
     assert.ok(true, "a11yAudit ran and didn't find any issues");
   });
 
-  test('a11yAudit catches violations successfully', async function (assert) {
+  test('a11yAudit catches violations successfully', async function (this: Context, assert) {
     await render(
       hbs`<AxeComponent><button type="button"></button></AxeComponent>`
     );
@@ -33,7 +38,7 @@ module('Integration | Helper | a11yAudit', function (hooks) {
     );
   });
 
-  test('a11yAudit can use custom axe options', async function (assert) {
+  test('a11yAudit can use custom axe options', async function (this: Context, assert) {
     await render(
       hbs`<AxeComponent><button type="button"></button></AxeComponent>`
     );


### PR DESCRIPTION
following the guides here: https://guides.emberjs.com/v5.7.0/typescript/application-development/testing/

This restores the needed `Element` to the TestContext, allowing Typescript checks to pass successfully