### PR TITLE
Fixes for `ember-beta` scenario failures

### DIFF
--- a/tests/dummy/app/templates/violations.hbs
+++ b/tests/dummy/app/templates/violations.hbs
@@ -41,6 +41,4 @@
 
 
 <footer class="p-violations__footer">
-  For more on <strong>accessible</strong> user interface patterns, check out
-    <a href="https://ember-a11y.github.io/a11y-demo-app/">Ember A11y's best-practices demo app</a>.
 </footer>

--- a/tests/integration/helpers/a11y-audit-test.ts
+++ b/tests/integration/helpers/a11y-audit-test.ts
@@ -21,15 +21,13 @@ module('Integration | Helper | a11yAudit', function (hooks) {
   });
 
   test('a11yAudit runs successfully with element context', async function (this: Context, assert) {
-    await render(hbs`<AxeComponent/>`);
+    await render(hbs`<div></div>`);
     await a11yAudit(this.element);
     assert.ok(true, "a11yAudit ran and didn't find any issues");
   });
 
   test('a11yAudit catches violations successfully', async function (this: Context, assert) {
-    await render(
-      hbs`<AxeComponent><button type="button"></button></AxeComponent>`
-    );
+    await render(hbs`<div><button type="button"></button></div>`);
 
     await assert.rejects(
       <Promise<any>>a11yAudit(this.element),
@@ -39,9 +37,7 @@ module('Integration | Helper | a11yAudit', function (hooks) {
   });
 
   test('a11yAudit can use custom axe options', async function (this: Context, assert) {
-    await render(
-      hbs`<AxeComponent><button type="button"></button></AxeComponent>`
-    );
+    await render(hbs`<div><button type="button"></button></div>`);
 
     await a11yAudit(this.element, {
       rules: {
@@ -55,9 +51,7 @@ module('Integration | Helper | a11yAudit', function (hooks) {
   });
 
   test('a11yAudit can use custom axe options as single argument', async function (assert) {
-    await render(
-      hbs`<AxeComponent><button type="button"></button></AxeComponent>`
-    );
+    await render(hbs`<div><button type="button"></button></div>`);
 
     await a11yAudit({
       rules: {


### PR DESCRIPTION
If merged, this should address the current failing tests in the `ember-beta` test scenario. 

There's still one test that is failing (advice welcome), so I'll keep trying to figure that out. I think something with how the test is set up, or how the test components are set up, is causing this failure to be triggered. But, looking at the associated test, there are several "skip these failures" elements but one still gets through. 🤔 
![CleanShot 2024-10-31 at 11 28 06](https://github.com/user-attachments/assets/cc737f3a-eef5-40ad-a691-420b1982804b)
