### PR TITLE
Fix sass deprecations

### DIFF
--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,10 +1,10 @@
-@import 'variables/variables';
+@use 'variables/_variables' as *;
 
-@import 'components/components';
-@import 'object-patterns/object-patterns';
-@import 'pages/pages';
-@import 'typography/typography';
-@import 'utilities/utilities';
+@use 'components/components';
+@use 'object-patterns/object-patterns';
+@use 'pages/pages';
+@use 'typography/typography';
+@use 'utilities/utilities';
 
 html {
   font-size: 100%;
@@ -33,9 +33,6 @@ ul {
   overflow-y: auto;
   background-color: $theme-color__offWhite;
   z-index: 1;
-
-  .application__header {
-  }
 
   .application__main-content {
     min-width: $min-width__main-content;

--- a/tests/dummy/app/styles/components/_button.scss
+++ b/tests/dummy/app/styles/components/_button.scss
@@ -1,3 +1,6 @@
+@use '../variables/_variables' as *;
+
+
 .c-button {
   display: flex;
   font-size: 1em;

--- a/tests/dummy/app/styles/components/_components.scss
+++ b/tests/dummy/app/styles/components/_components.scss
@@ -1,5 +1,5 @@
-@import 'button';
-@import 'image';
-@import 'menu-link-item';
-@import 'radio-track';
-@import 'violations-grid-item';
+@use 'button';
+@use 'image';
+@use 'menu-link-item';
+@use 'radio-track';
+@use 'violations-grid-item';

--- a/tests/dummy/app/styles/components/_menu-link-item.scss
+++ b/tests/dummy/app/styles/components/_menu-link-item.scss
@@ -1,3 +1,5 @@
+@use '../variables/_variables' as *;
+
 .c-menu-link-item {
   height: 3.25em;
   position: relative;

--- a/tests/dummy/app/styles/components/_radio-track.scss
+++ b/tests/dummy/app/styles/components/_radio-track.scss
@@ -1,4 +1,5 @@
 @use 'sass:math';
+@use '../variables/_variables' as *;
 
 $height__radio-selector-track-container: 4rem;
 $height__radio-selector-track-circle: $height__radio-selector-track-container *

--- a/tests/dummy/app/styles/components/_violations-grid-item.scss
+++ b/tests/dummy/app/styles/components/_violations-grid-item.scss
@@ -1,3 +1,5 @@
+@use '../variables/_variables' as *;
+
 .c-violations-grid-item {
   box-shadow: $box-shadow__card;
 

--- a/tests/dummy/app/styles/object-patterns/_content-box.scss
+++ b/tests/dummy/app/styles/object-patterns/_content-box.scss
@@ -1,3 +1,5 @@
+@use '../variables/_variables' as *;
+
 .o-content-box {
   box-sizing: border-box;
   padding: $padding__content-box;

--- a/tests/dummy/app/styles/object-patterns/_object-patterns.scss
+++ b/tests/dummy/app/styles/object-patterns/_object-patterns.scss
@@ -4,5 +4,5 @@
  * @see: https://www.google.com/search?q=object+orieinted+css&oq=object+orieinted+css&aqs=chrome..69i57j0l5.3247j0j7&sourceid=chrome&ie=UTF-8
  */
 
-@import 'content-box';
-@import 'menu-link';
+@use 'content-box';
+@use 'menu-link';

--- a/tests/dummy/app/styles/pages/_pages.scss
+++ b/tests/dummy/app/styles/pages/_pages.scss
@@ -1,1 +1,1 @@
-@import 'violations';
+@use 'violations';

--- a/tests/dummy/app/styles/pages/_violations.scss
+++ b/tests/dummy/app/styles/pages/_violations.scss
@@ -1,3 +1,5 @@
+@use '../variables/_variables' as *;
+
 $width__grid-item: 24rem;
 $height__grid-item: $width__grid-item * 0.55;
 $margin__grid-item--vertical: 0.5em;

--- a/tests/dummy/app/styles/typography/_headings.scss
+++ b/tests/dummy/app/styles/typography/_headings.scss
@@ -1,3 +1,5 @@
+@use '../variables/_variables' as *;
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
Since sass no longer supports `@import`, needed to switch it up to use `@use` instead, which also meant adding a few additional use declarations in files that were pulling in the variables. 

Going to try to find someone who regularly uses sass to review since I haven't used sass in this way in a long time and I'm not entirely positive it's the correct change. 