### PR TITLE
Merge `RunOptions` when calling `a11yAudit`.

### DIFF
--- a/addon-test-support/audit.ts
+++ b/addon-test-support/audit.ts
@@ -58,8 +58,11 @@ export function _normalizeRunParams(
     options = runOptions;
   }
 
-  if (typeof options !== 'object') {
-    options = getRunOptions() || {};
+  let globalRunOptions = getRunOptions() || {};
+  if (typeof options === 'object') {
+    options = { ...options, ...globalRunOptions };
+  } else {
+    options = globalRunOptions;
   }
 
   return [context, options];

--- a/addon-test-support/audit.ts
+++ b/addon-test-support/audit.ts
@@ -58,7 +58,7 @@ export function _normalizeRunParams(
     options = runOptions;
   }
 
-  options = { ...(options || {}), ...(getRunOptions() || {}) };
+  options = { ...options, ...getRunOptions() };
 
   return [context, options];
 }

--- a/addon-test-support/audit.ts
+++ b/addon-test-support/audit.ts
@@ -58,12 +58,7 @@ export function _normalizeRunParams(
     options = runOptions;
   }
 
-  let globalRunOptions = getRunOptions() || {};
-  if (typeof options === 'object') {
-    options = { ...options, ...globalRunOptions };
-  } else {
-    options = globalRunOptions;
-  }
+  options = { ...(options || {}), ...(getRunOptions() || {}) };
 
   return [context, options];
 }

--- a/tests/acceptance/a11y-audit-test.ts
+++ b/tests/acceptance/a11y-audit-test.ts
@@ -138,19 +138,23 @@ module('Acceptance | a11y audit', function (hooks) {
     assert.ok(true, 'the image-alt rule should be ignored');
   });
 
-  test('a11yAudit does not override default config', async function (assert) {
-    await visit('/ignored-image-alt');
+  test('a11yAudit does not override default config when passing additional rules', async function (assert) {
+    await visit('/ignored-image-alt-and-button-name');
 
     setRunOptions({
       rules: {
         // Disabled to test whether the config is
         // properly loaded in test environment
-        'image-alt': { enabled: false },
+        'button-name': { enabled: false },
       },
     });
 
     // Pass unrelated rules at runtime, should not override setRunOptions
-    await a11yAudit({ rules: { 'color-contrast': { enabled: false } } });
+    await a11yAudit({
+      rules: {
+        'image-alt': { enabled: false },
+      },
+    });
 
     assert.ok(true, 'the image-alt rule should be ignored');
   });

--- a/tests/acceptance/a11y-audit-test.ts
+++ b/tests/acceptance/a11y-audit-test.ts
@@ -137,4 +137,21 @@ module('Acceptance | a11y audit', function (hooks) {
 
     assert.ok(true, 'the image-alt rule should be ignored');
   });
+
+  test('a11yAudit does not override default config', async function (assert) {
+    await visit('/ignored-image-alt');
+
+    setRunOptions({
+      rules: {
+        // Disabled to test whether the config is
+        // properly loaded in test environment
+        'image-alt': { enabled: false },
+      },
+    });
+
+    // Pass unrelated rules at runtime, should not override setRunOptions
+    await a11yAudit({ rules: { 'color-contrast': { enabled: false } } });
+
+    assert.ok(true, 'the image-alt rule should be ignored');
+  });
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,4 +9,5 @@ export default class Router extends EmberRouter {
 Router.map(function () {
   this.route('violations', { path: '/' });
   this.route('ignored-image-alt');
+  this.route('ignored-image-alt-and-button-name');
 });

--- a/tests/dummy/app/templates/ignored-image-alt-and-button-name.hbs
+++ b/tests/dummy/app/templates/ignored-image-alt-and-button-name.hbs
@@ -1,0 +1,4 @@
+{{!-- template-lint-disable require-valid-alt-text --}}
+<img src="" />
+
+<button type="button" class="c-button" id="violations__empty-button" data-test-selector="empty-button"></button>


### PR DESCRIPTION
In an app that is disabling rules globally (through `setRunOptions`) and individually (through `a11yAudit`) currently the latter overrides the former.

This PR merges the options, letting the runtime call take precedence, but still allowing global options to pass through. I tested this patch in my host app, and rules were disabled as expected.