### PR TITLE
Remove unused body-parser dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@ember/test-waiters": "^2.4.3 || ^3.0.0",
     "@scalvert/ember-setup-middleware-reporter": "^0.1.1",
     "axe-core": "^4.6.3",
-    "body-parser": "^1.19.1",
     "broccoli-persistent-filter": "^3.1.2",
     "ember-auto-import": "^2.2.4",
     "ember-cli-babel": "^7.26.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3138,7 +3138,7 @@ body-parser@1.20.2:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-body-parser@^1.19.0, body-parser@^1.19.1:
+body-parser@^1.19.0:
   version "1.20.3"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.3.tgz#1953431221c6fb5cd63c4b36d53fab0928e548c6"
   integrity sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==


### PR DESCRIPTION
The body-parser dependency was added in https://github.com/ember-a11y/ember-a11y-testing/commit/cf0d1227c047725d3682101d3c6469145c8a3fdb#diff-2b7b86d547afb814ffca762b5a1162f99ed0f3fbf12e23bd59ed82343d6270e4 but later moved into Steve's `@scalvert/ember-setup-middleware-reporter` add-on. As such, we don't need to keep it up-to-date here