### PR TITLE
Tighten type imports

### DIFF
--- a/addon-test-support/audit.ts
+++ b/addon-test-support/audit.ts
@@ -1,4 +1,5 @@
-import { run, RunOptions, ElementContext, ContextObject } from 'axe-core';
+import type { RunOptions, ElementContext, ContextObject } from 'axe-core';
+import { run } from 'axe-core';
 import { mark, markEndAndMeasure } from './performance';
 import { getRunOptions } from './run-options';
 import { reportA11yAudit } from './reporter';

--- a/addon-test-support/logger.ts
+++ b/addon-test-support/logger.ts
@@ -1,4 +1,5 @@
-import axeCore, { AxeResults, NodeResult, RelatedNode, Result } from 'axe-core';
+import axeCore from 'axe-core';
+import type { AxeResults, NodeResult, RelatedNode, Result } from 'axe-core';
 
 /**
  * This file is heavily borrowed from https://github.com/dequelabs/react-axe/blob/d3245b32fc5ed19e3c7b2c43d2815fe63f5875cb/index.ts

--- a/addon-test-support/performance.ts
+++ b/addon-test-support/performance.ts
@@ -29,10 +29,11 @@ export function measure(comment: string, startMark: string, endMark: string) {
     if (HAS_PERFORMANCE) {
       performance.measure(comment, startMark, endMark);
     }
-  } catch (e) {
+  } catch (e: unknown) {
     // eslint-disable-next-line no-console
     console.warn(
       'performance.measure could not be executed because of ',
+      // @ts-ignore
       e.message,
     );
   }

--- a/addon-test-support/reporter.ts
+++ b/addon-test-support/reporter.ts
@@ -1,7 +1,7 @@
 import QUnit from 'qunit';
 import { AxeResults } from 'axe-core';
 import formatViolation from './format-violation';
-import { A11yAuditReporter } from './types';
+import type { A11yAuditReporter } from './types';
 import { storeResults } from './logger';
 
 export const DEFAULT_REPORTER = async (results: AxeResults) => {

--- a/addon-test-support/run-options.ts
+++ b/addon-test-support/run-options.ts
@@ -1,4 +1,4 @@
-import { RunOptions } from 'axe-core';
+import type { RunOptions } from 'axe-core';
 import { getContext } from '@ember/test-helpers';
 import { registerDestructor } from '@ember/destroyable';
 

--- a/addon-test-support/setup-global-a11y-hooks.ts
+++ b/addon-test-support/setup-global-a11y-hooks.ts
@@ -1,5 +1,5 @@
 import { registerHook, type HookUnregister } from '@ember/test-helpers';
-import { InvocationStrategy, AuditFunction } from './types';
+import type { InvocationStrategy, AuditFunction } from './types';
 import { getRunOptions } from './run-options';
 import a11yAudit from './audit';
 import { shouldForceAudit } from './should-force-audit';

--- a/addon-test-support/setup-middleware-reporter.ts
+++ b/addon-test-support/setup-middleware-reporter.ts
@@ -5,7 +5,7 @@ import {
   getContext,
   getTestMetadata,
 } from '@ember/test-helpers';
-import { AxeResults, Result } from 'axe-core';
+import type { AxeResults, Result } from 'axe-core';
 import { setCustomReporter } from './reporter';
 import { DEBUG } from '@glimmer/env';
 import { setEnableA11yAudit } from './should-force-audit';


### PR DESCRIPTION
I was seeing some errors about types from this add-on when running types in a client app using `verbatimModuleSyntax: true`. Could likely clean that up locally but figured I'd send these updates in so we all benefit. This doesn't change functionality, just ensures that we do type-only imports so we don't end up with larger bundle sizes by mistake