### PR TITLE
refactor(styles): move global styles to dedicated globals.scss file

### DIFF
--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,25 +1,6 @@
 @use 'variables/variables' as *;
 @use 'globals' as *;
 
-html {
-  font-size: 100%;
-}
-
-body {
-  position: relative;
-  margin: 0;
-  padding: 0;
-  width: 100%;
-  height: 100%;
-  background-color: $theme-color__offWhite;
-}
-
-ul {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
 .application {
   position: relative;
   width: 100%;
@@ -28,9 +9,6 @@ ul {
   overflow-y: auto;
   background-color: $theme-color__offWhite;
   z-index: 1;
-
-  // .application__header {
-  // }
 
   .application__main-content {
     min-width: $min-width__main-content;

--- a/tests/dummy/app/styles/globals.scss
+++ b/tests/dummy/app/styles/globals.scss
@@ -3,3 +3,23 @@
 @use 'pages/pages';
 @use 'typography/typography';
 @use 'utilities/utilities';
+@use 'variables/variables' as *;
+
+html {
+  font-size: 100%;
+}
+
+body {
+  position: relative;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background-color: $theme-color__offWhite;
+}
+
+ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
Refactored global styles into `globals.scss` and updated `app.scss` imports for better structure.

Resolves https://github.com/ember-a11y/ember-a11y-testing/issues/563