### PR TITLE
Update pnpm install commands in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           node-version-file: 'package.json'
           cache: pnpm
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
       - name: Run Tests
         run: pnpm test
       - name: Run Node Tests
@@ -70,7 +70,7 @@ jobs:
           node-version-file: 'package.json'
           cache: pnpm
       - name: Install Dependencies
-        run: pnpm install --no-lockfile
+        run: pnpm install
       - name: Run Tests
         run: pnpm test
 
@@ -95,7 +95,7 @@ jobs:
            pnpm dlx @embroider/try apply ${{ matrix.name }}
 
       - name: Install Dependencies
-        run: pnpm install --no-lockfile
+        run: pnpm install
       - name: Run Tests
         run: |
           pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           node-version-file: 'package.json'
           cache: pnpm
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
       - name: Run Tests
         run: pnpm test
       - name: Run Node Tests
@@ -70,7 +70,7 @@ jobs:
           node-version-file: 'package.json'
           cache: pnpm
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
       - name: Run Tests
         run: pnpm test
 
@@ -95,7 +95,7 @@ jobs:
            pnpm dlx @embroider/try apply ${{ matrix.name }}
 
       - name: Install Dependencies
-        run: pnpm install
+        run: pnpm install --no-frozen-lockfile
       - name: Run Tests
         run: |
           pnpm test


### PR DESCRIPTION
If merged, this PR updates the github `ci.yml` file. It changes some of the lockfile tags for `pnpm install`; it seems to be causing issues when dependabot wants to update a dependency.